### PR TITLE
Move JavaScript libraries into shared folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ The changes to the code depend on which kind of test you are running.
 
 ## Notes on possible Banner code improvements
 * Change banner JS code to improve reusability of markup, for A/B testing text changes: Load the `banner_text.hbs` template and render it as an usecaped variable into the markup in `banner_html.hbs`.
-* Move JavaScript libraries from `desktop` directory into `shared` directory.
 * Move `addSpace`, `addSpaceInstantly` and `displayBanner` to module `banner_display`. Move all the different ways of showing banners (overlay or scrollable, instant on, rollo and mini nag banner) into the new module. Remove similar functions from `banner_functions.js`. Add the 7.5 seconds delay for `displayBanner` as default but make delay configurable (for preview).
 * Move form initialization and validation code to module `form_validation`. Form elements (jQuery objects) should be passed in as constructor params. Also move validation functions from `banner_functions.js` into the new module.
 * Implement `impCount` and `bImpCount` as template placeholders instead of setting them with jQuery (they don't change with user interaction). Move the whole impression counting thing (reading and writing the cookie) to its own JavaScript module.

--- a/desktop/banner_ctrl.js
+++ b/desktop/banner_ctrl.js
@@ -14,16 +14,16 @@ const fundraisingBanner = {};
 const DevGlobalBannerSettings = require( './GlobalBannerSettings' );
 const GlobalBannerSettings = window.GlobalBannerSettings || DevGlobalBannerSettings;
 const Translations = {}; // will only be needed for English banner, German defaults are in DesktopBanner
-const BannerFunctions = require( './js/banner_functions' )( GlobalBannerSettings, Translations );
-const SizeIssues = require( './js/track_size_issues' );
-const getCampaignDaySentence = require( './js/count_campaign_days' )( GlobalBannerSettings[ 'campaign-start-date' ], GlobalBannerSettings[ 'campaign-end-date' ] );
-const getCustomDayName = require( './js/custom_day_name' );
-const TrackingEvents = require( './js/tracking_events' );
+const BannerFunctions = require( '../shared/banner_functions' )( GlobalBannerSettings, Translations );
+const SizeIssues = require( '../shared/track_size_issues' );
+const getCampaignDaySentence = require( '../shared/count_campaign_days' )( GlobalBannerSettings[ 'campaign-start-date' ], GlobalBannerSettings[ 'campaign-end-date' ] );
+const getCustomDayName = require( '../shared/custom_day_name' );
+const TrackingEvents = require( '../shared/tracking_events' );
 
 const bannerTemplate = require('./templates/banner_html.hbs');
 
 const $ = require( 'jquery' );
-require( './js/wlightbox.js' );
+require( '../shared/wlightbox.js' );
 
 const $bannerContainer = $( '#WMDE-Banner-Container' );
 const CampaignName = $bannerContainer.data( 'campaign-tracking' );

--- a/desktop/banner_var.js
+++ b/desktop/banner_var.js
@@ -17,18 +17,18 @@ const fundraisingBanner = {};
 const DevGlobalBannerSettings = require( './GlobalBannerSettings' );
 const GlobalBannerSettings = window.GlobalBannerSettings || DevGlobalBannerSettings;
 const Translations = {}; // will only be needed for English banner, German defaults are in DesktopBanner
-const BannerFunctions = require( './js/banner_functions' )( GlobalBannerSettings, Translations );
-const SizeIssues = require( './js/track_size_issues' );
-const getCampaignDaySentence = require( './js/count_campaign_days' )( GlobalBannerSettings[ 'campaign-start-date' ], GlobalBannerSettings[ 'campaign-end-date' ] );
-const getCustomDayName = require( './js/custom_day_name' );
-const TrackingEvents = require( './js/tracking_events' );
+const BannerFunctions = require( '../shared/banner_functions' )( GlobalBannerSettings, Translations );
+const SizeIssues = require( '../shared/track_size_issues' );
+const getCampaignDaySentence = require( '../shared/count_campaign_days' )( GlobalBannerSettings[ 'campaign-start-date' ], GlobalBannerSettings[ 'campaign-end-date' ] );
+const getCustomDayName = require( '../shared/custom_day_name' );
+const TrackingEvents = require( '../shared/tracking_events' );
 
 // For A/B testing different text or markup, load
 // const bannerTemplate = require('./banner_var.hbs');
 const bannerTemplate = require('./templates/banner_html.hbs');
 
 const $ = require( 'jquery' );
-require( './js/wlightbox.js' );
+require( '../shared/wlightbox.js' );
 
 const $bannerContainer = $( '#WMDE-Banner-Container' );
 const CampaignName = $bannerContainer.data( 'campaign-tracking' );

--- a/shared/banner_functions.js
+++ b/shared/banner_functions.js
@@ -1,0 +1,488 @@
+/*jshint latedef: nofunc */
+/*jshint unused: false */
+/* globals mw, alert */
+
+var $ = require( 'jquery' );
+
+module.exports = function ( GlobalBannerSettings, Translations ) {
+var finalDateTime = new Date( 2017, 11, 31, 23, 59, 59 ),
+	baseDate = GlobalBannerSettings[ 'donations-date-base' ] || '2017-11-01',
+	collectedBase = parseInt( GlobalBannerSettings.collectedBase || 0, 10 ),
+	donorsBase = parseInt( GlobalBannerSettings.donorsBase, 10 ),
+	donationsPerMinApproximation = parseFloat( GlobalBannerSettings[ 'appr-donations-per-minute' ] || 0.1 ),
+	donorsPerMinApproximation = parseFloat( GlobalBannerSettings[ 'appr-donators-per-minute' ] ),
+	noIntervalSelectedMessage = Translations[ 'no-interval-message' ] || 'Bitte wählen Sie zuerst ein Zahlungsintervall.',
+	amountEmptyMessage = Translations[ 'amount-empty-message' ] || 'Bitte wählen Sie zuerst einen Betrag.',
+	amountTooLowMessage = Translations[ 'amount-too-low-message' ] || 'Bitte geben Sie einen Spendenbetrag von min. 1€ ein.',
+	amountTooHighMessage = Translations[ 'amount-too-high-message' ] || 'Der Spendenbetrag ist zu hoch.',
+	allBannersImpCookie = 'centralnotice_banner_impression_count',
+	singleBannerImpCookie = 'centralnotice_single_banner_impression_count',
+	showBanner = true,
+	BannerEventHandlers = BannerEventHandlers || {},
+	messages = {
+		en: {
+			day: 'day',
+			days: 'days'
+		},
+		de: {
+			day: 'Tag',
+			days: 'Tage'
+		}
+	};
+
+
+BannerEventHandlers.handleAmountSelected = function () {
+	$( '#amount_other' ).prop( 'checked', false );
+	$( '#amount-other-input' ).val( '' );
+	// function call for backwards compatibility, once all banners support validation events, trigger validation:amount:ok instead
+	hideAmountError();
+};
+
+BannerEventHandlers.handleCustomAmount = function() {
+	$( 'input:radio[name=betrag_auswahl]' ).prop( 'checked', false );
+	$( '#amount_other' ).prop( 'checked', true );
+	hideAmountError();
+};
+
+function bannerHasValidationEventHandling() {
+	return typeof $( '#WMDE_Banner' ).data( 'validation-event-handling' ) !== 'undefined';
+}
+
+function initializeBannerEvents() {
+	var banner = $( '#WMDE_Banner' );
+
+	banner.on( 'amount:select', null, BannerEventHandlers.handleAmountSelected );
+	banner.on( 'amount:custom', null, BannerEventHandlers.handleCustomAmount );
+
+	if ( bannerHasValidationEventHandling() ) {
+		banner.trigger( 'validation:init', banner.data( 'validation-event-handling' ) );
+	}
+}
+
+function getDaysLeft() {
+	var daysLeft = Math.floor( new Date( finalDateTime - new Date() ) / 1000 / 60 / 60 / 24 );
+	return ( daysLeft < 0 ) ? 0 : daysLeft;
+}
+
+function getDaysRemaining( language ) {
+	var daysRemaining = getDaysLeft(),
+		lang = language || 'de';
+	return daysRemaining + ' ' + ( daysRemaining > 1 ? messages[ lang ].days : messages[ lang ].day );
+}
+
+function getSecsPassed() {
+	var startDate = baseDate.split( '-' ),
+		startDateObj = new Date( startDate[ 0 ], startDate[ 1 ] - 1, startDate[ 2 ] ),
+		maxSecs = Math.floor( new Date( finalDateTime - startDateObj ) / 1000 ),
+		secsPassed = Math.floor( ( new Date() - startDateObj ) / 1000 );
+
+	if ( secsPassed < 0 ) {
+		secsPassed = 0;
+	}
+	if ( secsPassed > maxSecs ) {
+		secsPassed = maxSecs;
+	}
+
+	return secsPassed;
+}
+
+function getApprDonationsRaw( rand ) {
+	var startDonations = collectedBase,
+		secsPast = getSecsPassed();
+
+	return startDonations + getApprDonationsFor( secsPast, rand );
+}
+
+function getApprDonatorsRaw( rand ) {
+	var startDonators = donorsBase,
+		secsPast = getSecsPassed();
+
+	return startDonators + getApprDonatorsFor( secsPast, rand );
+}
+
+function getApprDonationsFor( secsPast, rand ) {
+	var apprDontionsMinute = donationsPerMinApproximation,
+		randFactor = 0;
+
+	if ( rand === true ) {
+		randFactor = Math.floor( ( Math.random() ) + 0.5 - 0.2 );
+	}
+
+	return ( secsPast / 60 * ( apprDontionsMinute * ( 100 + randFactor ) ) / 100 );
+}
+
+function getApprDonatorsFor( secsPast, rand ) {
+	var apprDonatorsMinute = donorsPerMinApproximation,
+		randFactor = 0;
+
+	if ( rand === true ) {
+		randFactor = Math.floor( ( Math.random() ) + 0.5 - 0.2 );
+	}
+
+	return ( secsPast / 60 * ( apprDonatorsMinute * ( 100 + randFactor ) ) / 100 );
+}
+
+function getCurrentGermanDay() {
+	switch ( new Date().getDay() ) {
+		case 0:
+			return 'Sonntag';
+		case 1:
+			return 'Montag';
+		case 2:
+			return 'Dienstag';
+		case 3:
+			return 'Mittwoch';
+		case 4:
+			return 'Donnerstag';
+		case 5:
+			return 'Freitag';
+		case 6:
+			return 'Samstag';
+		default:
+			return '';
+	}
+}
+
+function getCurrentDayInEnglish() {
+	switch ( new Date().getDay() ) {
+		case 0:
+			return 'Sunday';
+		case 1:
+			return 'Monday';
+		case 2:
+			return 'Tuesday';
+		case 3:
+			return 'Wednesday';
+		case 4:
+			return 'Thursday';
+		case 5:
+			return 'Friday';
+		case 6:
+			return 'Saturday';
+		default:
+			return '';
+	}
+}
+
+function getDigitGroupingCharacter() {
+	switch ( mw.config.get( 'wgContentLanguage' ) ) {
+		case 'de':
+			return '.';
+		case 'en':
+			return ',';
+		default:
+			return '.';
+	}
+}
+
+function addPointsToNum( num ) {
+	// jscs:disable disallowImplicitTypeConversion
+	num = parseInt( num, 10 ) + '';
+	// jscs:enable disallowImplicitTypeConversion
+	num = num.replace( /\./g, ',' );
+	return num.replace( /(\d)(?=(\d\d\d)+(?!\d))/g, '$1' + getDigitGroupingCharacter() );
+}
+
+function floorF( num ) {
+	return Math.floor( num * 100 ) / 100;
+}
+
+function getImpCount() {
+	return parseInt( $.cookie( allBannersImpCookie ), 10 ) || 0;
+}
+
+function getBannerImpCount( bannerId ) {
+	var cookieValue, cookieData;
+
+	if ( $.cookie( singleBannerImpCookie ) ) {
+		cookieValue = $.cookie( singleBannerImpCookie );
+		cookieData = cookieValue.split( '|' );
+		if ( cookieData[ 0 ] === bannerId ) {
+			return parseInt( cookieData[ 1 ], 10 );
+		}
+	}
+	return 0;
+}
+
+function increaseImpCount() {
+	var impCount = getImpCount();
+	$.cookie( allBannersImpCookie, impCount + 1, { expires: 7, path: '/' } );
+	return impCount + 1;
+}
+
+function increaseBannerImpCount( bannerId ) {
+	var impCount = getBannerImpCount( bannerId );
+
+	$.cookie( singleBannerImpCookie, bannerId + '|' + ( impCount + 1 ), {
+		expires: 7,
+		path: '/'
+	} );
+	return ( impCount + 1 );
+}
+
+function validateForm() {
+	if ( !validateAndSetPeriod() ) {
+		return false;
+	}
+	if ( !validateAmount( getAmount() ) ) {
+		return false;
+	}
+}
+
+function showAmountError( text ) {
+	$( '#WMDE_Banner' ).trigger( 'validation:amount:error', text );
+}
+
+function hideAmountError() {
+	$( '#WMDE_Banner' ).trigger( 'validation:amount:ok' );
+}
+
+function showFrequencyError( text ) {
+	$( '#WMDE_Banner' ).trigger( 'validation:period:error', text );
+}
+
+function hideFrequencyError() {
+	$( '#WMDE_Banner' ).trigger( 'validation:period:ok' );
+}
+
+function validateAmount( amount ) {
+	// Check amount is at least the minimum
+	if ( amount === false ) {
+		showAmountError( amountEmptyMessage );
+		return false;
+	} else if ( amount < 1 ) {
+		showAmountError( amountTooLowMessage );
+		return false;
+	} else if ( amount > 99999 ) {
+		showAmountError( amountTooHighMessage );
+		return false;
+	}
+	hideAmountError();
+	return true;
+}
+
+/**
+ * Check the "interval" radio buttons and change the "period" and "intervalType" fields accordingly.
+ * If "periodically" is selected but no interval is selected, this function
+ * will display an error message via alert.
+ */
+function validateAndSetPeriod() {
+	var form = document.donationForm;
+	if ( $( '#interval_multiple' ).is( ':checked' ) ) {
+		if ( $( 'input[name=interval]:checked', form ).length !== 1 ) {
+			showFrequencyError( noIntervalSelectedMessage );
+			return false;
+		} else {
+			$( '#intervalType' ).val( '1' );
+			$( '#periode' ).val( $( 'input[name=interval]:checked', form ).val() );
+		}
+	} else if ( $( '#interval_onetime' ).is( ':checked' ) )  {
+		$( '#periode' ).val( '0' );
+		$( '#intervalType' ).val( '0' );
+	} else {
+		// check if we have interval tabs (non-fulltop-banner)
+		if ( $( '.interval_tab' ).length > 0 ) {
+			$( '#periode' ).val( '0' );
+			$( '#intervalType' ).val( '0' );
+				}
+		else {
+			showFrequencyError( noIntervalSelectedMessage );
+			return false;
+		}
+	}
+	hideFrequencyError();
+	return true;
+}
+
+function getAmount() {
+	var amount = null,
+		otherAmount = $( '#amount-other-input' ).val(),
+		form = document.donationForm;
+
+	amount = $( 'input[name=betrag_auswahl]:checked' ).val();
+
+	if ( otherAmount !== '' ) {
+		otherAmount = otherAmount.replace( /[,.](\d)$/, '\:$10' );
+		otherAmount = otherAmount.replace( /[,.](\d)(\d)$/, '\:$1$2' );
+		otherAmount = otherAmount.replace( /[\$,.]/g, '' );
+		otherAmount = otherAmount.replace( /:/, '.' );
+		$( '#amount-other-input' ).val( otherAmount );
+		amount = otherAmount;
+	}
+
+	if ( amount === null || isNaN( amount ) ) {
+		return false;
+	}
+
+	return amount;
+}
+
+function addBannerSpace() {
+	var expandableBannerHeight = $( 'div#WMDE_Banner' ).height() + 44,
+		bannerDivElement = $( '#WMDE_Banner' ),
+		skin = getSkin();
+
+	if ( !showBanner ) {
+		return;
+	}
+	switch ( skin ) {
+			case 'vector':
+				bannerDivElement.css( 'top', 0 );
+				bannerDivElement.css( 'display', 'block' );
+				$( '#mw-panel' ).css( 'top', expandableBannerHeight + 160 );
+				$( '#mw-head' ).css( 'top', expandableBannerHeight );
+				$( '#mw-page-base' ).css( 'paddingTop', expandableBannerHeight );
+				break;
+			case 'minerva':
+				$( '#mw-mf-viewport' ).css( 'top', expandableBannerHeight );
+				$( '#mw-mf-page-center, #mw-mf-page-left' ).css( 'top', expandableBannerHeight );
+			break;
+			case 'monobook':
+				$( '#globalWrapper' ).css( 'position', 'relative' );
+				$( '#globalWrapper' ).css( 'top', expandableBannerHeight );
+				bannerDivElement.css( 'top', '-20px' );
+				bannerDivElement.css( 'background', 'none' );
+				break;
+		}
+	}
+
+function addBannerSpaceWithRollo() {
+	var expandableBannerHeight = $( 'div#WMDE_Banner' ).height() + 44,
+		bannerDivElement = $( '#WMDE_Banner' ),
+		skin = getSkin();
+
+	if ( !showBanner ) {
+		return;
+	}
+	switch ( skin ) {
+		case 'vector':
+			bannerDivElement.css( 'top', 0 - expandableBannerHeight );
+			$( '#mw-panel' ).animate( { top: expandableBannerHeight + 160 }, 1000 );
+			$( '#mw-head' ).animate( { top: expandableBannerHeight }, 1000 );
+			$( '#mw-page-base' ).animate( { paddingTop: expandableBannerHeight }, 1000 );
+			break;
+		case 'minerva':
+			$( '#mw-mf-viewport' ).css( 'top', expandableBannerHeight );
+			$( '#mw-mf-page-center, #mw-mf-page-left' ).css( 'top', expandableBannerHeight );
+			break;
+		case 'monobook':
+			$( '#globalWrapper' ).css( 'position', 'relative' );
+			$( '#globalWrapper' ).css( 'top', expandableBannerHeight );
+			bannerDivElement.css( 'top', '-20px' );
+			bannerDivElement.css( 'background', 'none' );
+			break;
+	}
+	bannerDivElement.css( 'display', 'block' );
+	bannerDivElement.animate( { top: 0 }, 1000 );
+}
+
+function removeBannerSpace() {
+	var skin = getSkin();
+	switch ( skin ) {
+		case 'vector':
+			$( '#mw-panel' ).css( 'top', 160 );
+			$( '#mw-head' ).css( 'top', 0 );
+			$( '#mw-page-base' ).css( 'padding-top', 0 );
+			break;
+		case 'minerva':
+			$( '#mw-mf-viewport' ).css( 'top', 0 );
+			$( '#mw-mf-page-center, #mw-mf-page-left' ).css( 'top', 0 );
+			break;
+		case 'monobook':
+			$( '#globalWrapper' ).css( 'position', 'relative' );
+			$( '#globalWrapper' ).css( 'top', 0 );
+			break;
+	}
+}
+
+function addSpaceForIntervalOptions() {
+	var $intervalOptionsContainer = $( 'div.interval-options' ),
+		expandableBannerHeight = $intervalOptionsContainer.height();
+	if ( $intervalOptionsContainer && $intervalOptionsContainer.is( ':visible' ) ) {
+		return;
+	}
+
+	switch ( getSkin() ) {
+		case 'vector':
+			$( '#mw-panel' ).css( { top: parseInt( $( '#mw-panel' ).css( 'top' ), 10 ) + expandableBannerHeight + 'px' } );
+			$( '#mw-head' ).css( { top: parseInt( $( '#mw-head' ).css( 'top' ), 10 ) + expandableBannerHeight + 'px' } );
+			$( '#mw-page-base' ).css( { paddingTop: parseInt( $( '#mw-page-base' ).css( 'padding-top' ), 10 ) + expandableBannerHeight + 'px' } );
+			break;
+		case 'minerva':
+			$( '#mw-mf-viewport' ).css( { top: parseInt( $( '#mw-mf-viewport' ).css( 'top' ), 10 ) + expandableBannerHeight + 'px' } );
+			$( '#mw-mf-page-center, #mw-mf-page-left' ).css( { top: parseInt( $( '#mw-mf-page-center' ).css( 'top' ), 10 ) + expandableBannerHeight + 'px' } );
+			break;
+		case 'monobook':
+			$( '#globalWrapper' ).css( { top: parseInt( $( '#globalWrapper' ).css( 'top' ), 10 ) + expandableBannerHeight + 'px' } );
+			break;
+	}
+}
+
+function removeSpaceForIntervalOptions() {
+	var $intervalOptionsContainer = $( 'div.interval-options' ),
+		expandableBannerHeight = $intervalOptionsContainer.height() + 5;
+	if ( $intervalOptionsContainer && !$intervalOptionsContainer.is( ':visible' ) ) {
+		return;
+	}
+
+	switch ( getSkin() ) {
+		case 'vector':
+			$( '#mw-panel' ).css( { top: ( parseInt( $( '#mw-panel' ).css( 'top' ), 10 ) - expandableBannerHeight ) + 'px' } );
+			$( '#mw-head' ).css( { top: ( parseInt( $( '#mw-head' ).css( 'top' ), 10 ) - expandableBannerHeight ) + 'px' } );
+			$( '#mw-page-base' ).css( { paddingTop: ( parseInt( $( '#mw-page-base' ).css( 'padding-top' ), 10 ) - expandableBannerHeight ) + 'px' } );
+			break;
+		case 'minerva':
+			$( '#mw-mf-viewport' ).css( { top: ( parseInt( $( '#mw-mf-viewport' ).css( 'top' ), 10 ) - expandableBannerHeight ) + 'px' } );
+			$( '#mw-mf-page-center, #mw-mf-page-left' ).css( { top: ( parseInt( $( '#mw-mf-page-center' ).css( 'top' ), 10 ) - expandableBannerHeight ) + 'px' } );
+			break;
+		case 'monobook':
+			$( '#globalWrapper' ).css( { top: ( parseInt( $( '#globalWrapper' ).css( 'top' ), 10 ) - expandableBannerHeight ) + 'px' } );
+			break;
+	}
+}
+
+/**
+ * Calculate the number of donors needed, given an average donation amount.
+ *
+ * This function cannot return less than 0 donors when the target has been reached.
+ *
+ * @param  {number} averageDonation Average donation amount in EUR
+ * @return {number} Number of donors needed (rounded up)
+ */
+function getRemainingDonorsNeeded( averageDonation ) {
+	var dRemaining, dCollected, numDonors;
+	dCollected = getApprDonationsRaw();
+	dRemaining = GlobalBannerSettings.goalSum - dCollected;
+	numDonors = Math.ceil( dRemaining / averageDonation );
+	return Math.max( 0, numDonors );
+}
+
+function getSkin() {
+	if ( onMediaWiki() ) {
+		return window.mw.config.get( 'skin' );
+	}
+	return 'vector';
+}
+
+function onMediaWiki() {
+	return typeof window.mw === 'object' && typeof window.mw.centralNotice !== 'undefined';
+}
+
+return {
+	onMediaWiki: onMediaWiki,
+	getSkin: getSkin,
+	validateForm: validateForm,
+	validateAndSetPeriod: validateAndSetPeriod,
+	validateAmount: validateAmount,
+	getAmount: getAmount,
+	increaseImpCount: increaseImpCount,
+	increaseBannerImpCount: increaseBannerImpCount,
+	getDaysRemaining: getDaysRemaining,
+	getCurrentGermanDay: getCurrentGermanDay,
+	initializeBannerEvents: initializeBannerEvents,
+	showFrequencyError: showFrequencyError,
+	showAmountError: showAmountError,
+	hideAmountError: hideAmountError,
+	hideFrequencyError: hideFrequencyError
+}
+}

--- a/shared/count_campaign_days.js
+++ b/shared/count_campaign_days.js
@@ -1,0 +1,55 @@
+module.exports = function ( startDate, endDate ) {
+  function getCampaignDayString() {
+	var daysSinceStart = getDaysSinceCampaignStart() + 1;
+	return daysSinceStart + '.';
+}
+
+function dateObjectFromString( dateStr ) {
+        var dateParts = dateStr.split( '-' );
+        return new Date( dateParts[ 0 ], dateParts[ 1 ] - 1, dateParts[ 2 ] );
+}
+
+function getDaysSinceCampaignStart() {
+	var startDay = dateObjectFromString( startDate );
+	return Math.floor( new Date( new Date() - startDay ) / 1000 / 60 / 60 / 24 );
+}
+
+function getDaysUntilCampaignEnds() {
+     	var endDay = dateObjectFromString( endDate ),
+            dayDelta = endDay - new Date();
+        if ( dayDelta > 0 ) {
+            return Math.floor( dayDelta / 1000 / 60 / 60 / 24 );
+        } else {
+            return 0;
+        }
+}
+
+function getCampaignDaySentence() {
+        if ( getDaysUntilCampaignEnds() == 0 ) {
+                return 'Heute ist der letzte Tag unserer Spendenkampagne.';
+        } else if ( getDaysUntilCampaignEnds() < 7 ) {
+                return 'Dies ist die letzte Woche unserer Spendenkampagne.';
+        } else if ( getDaysSinceCampaignStart() > 0 ) {
+		return 'Heute ist der ' + getCampaignDayString() + ' Tag unserer Spendenkampagne.';
+	}
+  if ( getDaysSinceCampaignStart() < 0 ) {
+    return 'Heute bitten wir Sie um Ihre Unterstützung.';
+  }
+	return 'Heute beginnt unsere Spendenkampagne.';
+}
+
+function getEnglishCampaignDaySentence() {
+        if ( getDaysUntilCampaignEnds() == 0 ) {
+                return 'Today is the final day of our donation campaign.';
+        } else if ( getDaysUntilCampaignEnds() < 7 ) {
+                return 'This is the last week of our donation campaign.';
+        }
+	return '';
+}
+
+
+return function ( language ){
+  return language === 'de' ? getCampaignDaySentence() : getEnglishCampaignDaySentence()
+}
+
+}

--- a/shared/custom_day_name.js
+++ b/shared/custom_day_name.js
@@ -1,0 +1,47 @@
+/*jshint unused: false */
+
+var customDayNames = {
+	'06.12': {
+		de: 'Nikolaustag',
+		en: 'St Nicholas Day'
+	},
+	'24.12': {
+		de: 'Weihnachtsfeiertag',
+		en: 'Christmas Day'
+	},
+	'25.12': {
+		de: '1. Weihnachtsfeiertag',
+		en: 'Christmas Day'
+	},
+	'26.12': {
+		de: '2. Weihnachtsfeiertag',
+		en: 'Christmas Day'
+	}
+};
+
+function getDateString( date ) {
+	var dateString = '',
+		day = date.getDate(),
+		month = date.getMonth() + 1;
+	if ( day < 10 ) {
+		dateString += '0';
+	}
+	dateString += day;
+	dateString += '.';
+	if ( month < 10 ) {
+		dateString += month;
+	}
+	dateString += month;
+	return dateString;
+}
+
+function getCustomDayName( fallbackFunction, lang ) {
+	var	currentDateString = getDateString( new Date() ),
+		language = lang || 'de';
+	if ( currentDateString in customDayNames ) {
+		return customDayNames[ currentDateString ][ language ];
+	}
+	return fallbackFunction();
+}
+
+module.exports = getCustomDayName;

--- a/shared/track_size_issues.js
+++ b/shared/track_size_issues.js
@@ -1,0 +1,47 @@
+const $ = require( 'jquery' );
+
+/**
+ * Get number of pixels remaining in viewport after the banner height was subtracted.
+ * @param jQuery bannerElement
+ * @return Number
+ */
+const getVisibleWikipedia = function ( bannerElement ) {
+    return $( window ).height() - bannerElement.height();
+}
+
+/**
+ * Check if Banner takes too much screen space and track the incident
+ * @param jQuery bannerElement
+ */
+const trackSizeIssues = function( bannerElement, trackingLink, trackRatio ) {
+    var bannerHeight = bannerElement.height(),
+        viewportHeight = $( window ).height(),
+        viewportWidth = $( window ).width(),
+        threshold = 180, // Pixels
+        resolutions = '';
+
+    if ( getVisibleWikipedia( bannerElement ) > threshold ) {
+        return;
+    }
+    if ( Math.random() > trackRatio ) {
+        return;
+    }
+    // Avoid multiple tracking when trackSpaceIssues is called multiple times
+    if ( $( '#WMDE_Banner-track-sizes', bannerElement ).length > 0 ) {
+        return;
+    }
+    resolutions = [
+        bannerHeight,
+        viewportWidth + 'x' + viewportHeight,
+        screen.width + 'x' + screen.height,
+        window.outerWidth + 'x' + window.outerHeight
+    ].join( '--' );
+
+    var trackUrl = trackingLink + resolutions;
+    bannerElement.append( $( '<img id="WMDE_Banner-track-sizes" width="1" height="1">' ).attr( 'src', trackUrl ) );
+}
+
+module.exports = {
+  trackSizeIssues: trackSizeIssues,
+  getVisibleWikipedia: getVisibleWikipedia
+}

--- a/shared/tracking_events.js
+++ b/shared/tracking_events.js
@@ -1,0 +1,32 @@
+function TrackingEvents( bannerName, trackingImage ) {
+    this.bannerName = bannerName;
+    this.trackingImage = trackingImage;
+    this.baseUrl = 'https://tracking.wikimedia.de/piwik.php?idsite=1&rec=1&url=https://spenden.wikimedia.de';
+}
+
+TrackingEvents.prototype.trackClickEvent = function ( trackedElement, actionName, trackRatio ) {
+    const self = this;
+    if ( typeof trackRatio === 'undefined' ) {
+        trackRatio = 1;
+    }
+    trackedElement.click( function () {
+        if ( Math.random() < trackRatio ) {
+            self.trackingImage.attr( 'src', self.getTrackingURL( actionName ) );
+        }
+    } );
+};
+
+/**
+ * @param {string} actionName
+ * @return {string} Tracking URL
+ */
+TrackingEvents.prototype.getTrackingURL = function ( actionName ) {
+    return [
+                this.baseUrl,
+                actionName,
+                this.bannerName
+            ].join( '/' );
+
+};
+
+module.exports = TrackingEvents;

--- a/shared/wlightbox.js
+++ b/shared/wlightbox.js
@@ -1,0 +1,197 @@
+( function ( $ ) {
+	var IE = ( !!window.ActiveXObject && +( /msie\s(\d+)/i.exec( navigator.userAgent )[ 1 ] ) ) || undefined;
+
+	function getArrowDirection( elementOptions ) {
+
+		var arrowDirections = {
+				Top: 'left',
+				Bottom: 'left',
+				Left: 'top',
+				Right: 'top'
+			},
+			d, optionName;
+		for ( d in arrowDirections ) {
+			if ( arrowDirections.hasOwnProperty( d ) ) {
+				optionName = 'arrow' + d;
+				if ( elementOptions[ optionName ] ) {
+					return { direction: d.toLowerCase(), cssProperty: arrowDirections[ d ], optionName: optionName };
+				}
+			}
+		}
+		return false;
+	}
+
+	$.fn.wlightbox = function ( options ) {
+		return this.each( function () {
+			var s = this,
+				self = $( this ),
+				$inlineContentObj = $( $( self ).attr( 'data-href' ) ),
+				$inlineContentObjContainer = $( $( self ).attr( 'data-href' ) ).parent(),
+				$wlightbox = $( '<div id="wlightbox"></div>' ),
+				$wlightboxContent = $( '<div id="wlightbox-content"></div>' ),
+				$wlightboxClose = $( '<a href="#" id="wlightbox-close" class="icon-cross" title="close"></a>' ),
+				$wlightboxOverlay = $( '<div id="wlightbox-overlay"></div>' ),
+				$wlightboxCss, open = false;
+
+			s.init = function () {
+				s.options = $.extend( {}, $.fn.wlightbox.defaultOptions, options );
+
+				// change numeric value into css value with 'px'
+				$.each( 'top bottom left right arrowLeft arrowRight'.split( ' ' ), function ( index, item ) {
+					if ( $.isNumeric( s.options[ item ] ) ) {
+						s.options[ item ] += 'px';
+					}
+				} );
+
+				// open wlightbox
+				self.click( function ( e ) {
+					s.create();
+					s.initEventHandling();
+					s.open();
+
+					e.preventDefault();
+				} );
+			};
+
+			s.create = function () {
+				var arrowData;
+				if ( $( '#wlightbox' ).length == 0 ) {
+					$( s.options.container ).append( $wlightbox );
+				}
+
+				$wlightbox.empty();
+
+				if ( $( '#wlightbox-content' ).length == 0 ) {
+					$wlightbox.append( $wlightboxContent );
+				}
+				if ( $( '#wlightbox-overlay' ).length == 0 ) {
+					$( s.options.overlayContainer ).append( $wlightboxOverlay );
+				}
+
+				// close button
+				if ( s.options.closeButton && $( '#wlightbox-close' ).length == 0 ) {
+					$wlightbox.append( $wlightboxClose );
+				}
+
+				// position & size
+				$.each( 'top bottom left right width height maxWidth maxHeight'.split( ' ' ), function ( index, item ) {
+					switch ( typeof s.options[ item ] ) {
+						case "undefined":
+						    return;
+						case "function":
+							$wlightbox.css( item, s.options[ item ]( item ) );;
+						default:
+							$wlightbox.css( item, s.options[ item ] );
+					}
+				} );
+
+				s.initArrow();
+
+			};
+
+			s.initArrow = function () {
+				var arrowData = getArrowDirection( s.options ),
+					cssString;
+				if ( !arrowData ) {
+					return;
+				}
+				cssString = '#wlightbox.arrow-box-' + arrowData.direction + '::before { ' +
+							arrowData.cssProperty + ': ' + s.options[ arrowData.optionName ] + ' }';
+				if ( !IE ) {
+					$wlightboxCss = $( '<style type="text/css" id="wlightbox-css"></style>' );
+					$wlightboxCss.empty();
+
+					if ( $( '#wlightbox-css' ).length == 0 ) {
+						$( 'head' ).append( $wlightboxCss );
+					}
+
+					// init arrow-box
+					$wlightboxCss.append( cssString );
+
+				} else {
+					$.fn.wlightbox.css.cssText = cssString;
+				}
+				$wlightbox.attr( 'class', 'arrow-box-' + arrowData.direction );
+			};
+
+			s.initEventHandling = function () {
+				// close
+				if ( s.options.closeButton ) {
+					$wlightboxClose.on( 'click', function ( e ) {
+						e.preventDefault();
+						s.close();
+					} );
+				}
+
+				if ( s.options.overlayClose ) {
+					$wlightboxOverlay.click( function ( e ) {
+						e.preventDefault();
+						s.close();
+					} );
+				}
+
+				$( document ).keydown( function ( e ) {
+					var key = e.keyCode;
+					if ( open && s.options.escKey && key === 27 ) {
+						e.preventDefault();
+						s.close();
+					}
+				} );
+			};
+
+			s.open = function () {
+				if ( $inlineContentObj.length > 0 ) {
+					$inlineContentObj.appendTo( $wlightboxContent );
+				}
+
+				$wlightbox.hide().fadeIn( s.options.speedIn );
+				$wlightboxOverlay.hide().fadeTo( s.options.speedIn, s.options.opacity / 100, function () {
+					open = true;
+				} );
+			};
+
+			s.close = function () {
+				// hide & remove content
+				$wlightboxOverlay.fadeOut( s.options.speedOut, function () {
+					$wlightboxOverlay.remove();
+				} );
+
+				$wlightbox.fadeOut( s.options.speedOut, function () {
+					$inlineContentObj.appendTo( $inlineContentObjContainer );
+
+					$wlightbox.remove();
+				} );
+
+				open = false;
+			};
+
+			s.init();
+		} );
+	};
+	$.fn.wlightbox.defaultOptions = {
+		container: 'body',
+		overlayContainer: 'body',
+		speedIn: 300,
+		speedOut: 300,
+		opacity: 60,
+		overlayClose: true,
+		escKey: true,
+		closeButton: true,
+		top: false,
+		bottom: false,
+		left: false,
+		right: false,
+		arrowBox: true,
+		arrowLeft: false,
+		arrowRight: false,
+		width: false,
+		height: false,
+		maxWidth: false,
+		maxHeight: false
+	};
+
+	if ( IE ) {
+		$.fn.wlightbox.css = document.createStyleSheet( '' );
+	}
+
+} )( jQuery );


### PR DESCRIPTION
Banner functionality that is relatively independent from markup is moved
into a shared folder where it can be used by all banner channels
(mobile, English, wp.de, etc).

Not in this PR: Remove all jQuery selections except on #WMDE_Banner from the 
shared library. Culprits are some deprecated functions in
banner_functions and wlightbox.

This is for https://phabricator.wikimedia.org/T173918