### PR TITLE
Convert modifiers to elements

### DIFF
--- a/desktop/css/styles.pcss
+++ b/desktop/css/styles.pcss
@@ -64,13 +64,16 @@
         margin: .25em 0;
     }
 
-    .text__paragraph .text-highlight {
+    .text__highlight {
         border-bottom: solid 3px #990000;
         padding: 0 .1em;
         background: transparent;
     }
 
-    .text__paragraph--hidden-placeholder {
+    /* This is for keeping the same banner size when testing different banner texts.
+       The placeholder text element should contain the text that was removed.
+     */
+    .text__hidden-placeholder {
         visibility: hidden;
     }
 

--- a/desktop/templates/banner_text.hbs
+++ b/desktop/templates/banner_text.hbs
@@ -7,7 +7,7 @@
 	{{ campaignDaySentence }}
 	Wikipedia wird von Freiwilligen geschrieben und durch Spenden von durchschnittlich 20 € finanziert.
 	Jetzt sind Sie in Deutschland gefragt.
-	<span class="text-highlight">
+	<span class="text__highlight">
 		Wenn alle, die das jetzt lesen, einen kleinen Beitrag leisten, ist unsere Spendenkampagne in einer Stunde vorüber.
 	</span>
 	Schon der Preis einer Tasse Kaffee würde genügen. Es ist leicht, diese Nachricht zu ignorieren und die meisten werden

--- a/desktop/templates/banner_text_var.hbs
+++ b/desktop/templates/banner_text_var.hbs
@@ -5,7 +5,7 @@
 <p class="text__paragraph">
 	Verzeihen Sie die Störung. Jetzt sind Sie in Deutschland gefragt.
 	Wikipedia wird von Freiwilligen geschrieben und durch Spenden von durchschnittlich 20 € finanziert.
-	<span class="text-highlight">
+	<span class="text__highlight">
 		Wenn alle, die das jetzt lesen, einen kleinen Beitrag leisten, ist unsere Spendenkampagne in einer Stunde vorüber.
 	</span>
 	Schon der Preis einer Tasse Kaffee würde genügen. Es ist leicht, diese Nachricht zu ignorieren und die meisten werden


### PR DESCRIPTION
Since the previous "modifiers" did not modify a whole block or element
I think it's better to define them as standalone elements.

Also added some docs on the purpose of the `text__hidden-placeholder`
class.

This addresses the concerns from #9 