### PR TITLE
trim highlight element's text

### DIFF
--- a/shared/animate_highlight.js
+++ b/shared/animate_highlight.js
@@ -16,7 +16,7 @@ function addCharacterSpans( $elem, startCharacter, endCharacter ) {
 }
 
 function getNumberOfCharacters( $elem ) {
-	return $elem.text().length;
+	return $elem.text().trim().length;
 }
 
 function highlightNthCharacter( $elem, n, className ) {


### PR DESCRIPTION
Currently, the highlight animator creates too much `<span>`s, when the element `#to-highlight` contains spaces and/or line breaks. This PR fixes this, but in general the highlight animator needs some refactoring.