### PR TITLE
T173920 Desktop banner on wikipedia.de

### DIFF
--- a/campaign_info.toml
+++ b/campaign_info.toml
@@ -1,6 +1,7 @@
 # A Campaign with global settings
 [desktop]
 campaign_tracking = "09-ba-171006"
+preview_link = "/wiki/Wikipedia:Hauptseite?banner=B17WMDE_webpack_prototype&devbanner={{banner}}"
 
 # Banners of the campaign, key after "banners" can be anything
 [desktop.banners.ctrl]
@@ -13,9 +14,10 @@ filename = "./desktop/banner_var.js"
 pagename = "B17WMDE_09_171006_var"
 tracking = "org-09-171006-var"
 
+
 [mobile]
 campaign_tracking = "mob01-ba-170904"
-preview_skin = "minerva"
+preview_link = "/wiki/Wikipedia:Hauptseite?useskin=minerva&banner=B17WMDE_webpack_prototype&devbanner={{banner}}"
 
 [mobile.banners.ctrl]
 filename = "./mobile/banner_ctrl.js"
@@ -26,3 +28,18 @@ tracking = "org-mob01-170904-ctrl"
 filename = "./mobile/banner_var.js"
 pagename = "B17WMDE_mob_01_170904_var"
 tracking = "org-mob01-170904-var"
+
+
+[wikipediade]
+campaign_tracking = "09-ba-171006"
+preview_link = "/wikipedia.de?bannertest=Banner/B17WMDE_webpack_prototype&devbanner={{banner}}"
+
+[wikipediade.banners.ctrl]
+filename = "./wikipedia.de/banner_ctrl.js"
+pagename = "FR2016_09_171007_ctrl"
+tracking = "org-09-171006-ctrl"
+
+[wikipediade.banners.var]
+filename = "./wikipedia.de/banner_var.js"
+pagename = "FR2016_09_171007_var"
+tracking = "org-09-171006-var"

--- a/desktop/css/styles.pcss
+++ b/desktop/css/styles.pcss
@@ -9,6 +9,7 @@
 
     & {
         display: none;
+        font-size: 16px;
     }
 
     /**
@@ -51,7 +52,9 @@
         margin-left: 2em;
     }
 
-    .text__headline {}
+    .text__headline {
+        margin: 0.4em 0 0.5em 0;
+    }
 
     .text__headline--italic {
         font-style: italic;
@@ -115,6 +118,12 @@
 
     .application-of-funds-link {
         color: #000;
+        text-decoration: none;
+    }
+
+    .application-of-funds-link:hover,
+    .application-of-funds-link:focus {
+        text-decoration: underline;
     }
 
     /* Form styling */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,27 +5,29 @@ const CommonConfig = require( './webpack.common.js' );
 const webpack = require( 'webpack' );
 
 module.exports = Merge( CommonConfig, {
-  entry: {
-    'loader': './webpack/loader.js'
-  },
-  plugins: [
-      new webpack.HotModuleReplacementPlugin(),
-      new webpack.DefinePlugin( {
-          CAMPAIGNS: JSON.stringify( toml.parse( fs.readFileSync( 'campaign_info.toml', 'utf8' ) ) )
-      } )
-  ],
-  devServer: {
-      port: 8084,
-      hot: true,
-      contentBase: './dist',
-	  headers: {
-		  'Access-Control-Allow-Origin': '*'
-	  },
-      proxy: [{
-          context: [ '/wiki', '/w', '/static' ],
-          target: 'https://de.wikipedia.org',
-          secure: false,
-          headers: { host:'de.wikipedia.org' }
-      }]
-  }
+	entry: {
+		'loader': './webpack/loader.js'
+	},
+	plugins: [
+		new webpack.HotModuleReplacementPlugin(),
+		new webpack.DefinePlugin( {
+			CAMPAIGNS: JSON.stringify( toml.parse( fs.readFileSync( 'campaign_info.toml', 'utf8' ) ) )
+		} )
+	],
+	devServer: {
+		port: 8084,
+		hot: true,
+		contentBase: './dist',
+		headers: {
+			'Access-Control-Allow-Origin': '*'
+		},
+		proxy: [
+			{
+				context: [ '/wiki', '/w', '/static' ],
+				target: 'https://de.wikipedia.org',
+				secure: false,
+				headers: { host: 'de.wikipedia.org' }
+			}
+		]
+	}
 } );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,12 @@ module.exports = Merge( CommonConfig, {
 		},
 		proxy: [
 			{
+				context: [ '/wikipedia.de', '/FundraisingBanners', '/img', '/js', '/style.css', '/suggest.js' ],
+				pathRewrite: { '^/wikipedia.de' : '' },
+				target: 'https://wikipedia.de',
+				changeOrigin: true
+			},
+			{
 				context: [ '/wiki', '/w', '/static' ],
 				target: 'https://de.wikipedia.org',
 				changeOrigin: true

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,8 +25,7 @@ module.exports = Merge( CommonConfig, {
 			{
 				context: [ '/wiki', '/w', '/static' ],
 				target: 'https://de.wikipedia.org',
-				secure: false,
-				headers: { host: 'de.wikipedia.org' }
+				changeOrigin: true
 			}
 		]
 	}

--- a/webpack/banner_selection_list.hbs
+++ b/webpack/banner_selection_list.hbs
@@ -1,6 +1,12 @@
-<p>Select a Banner:</p>
+<h1>Select a Banner</h1>
+
 <ul>
-    {{#each banners }}
-        <li><a href="{{url}}">{{name}}</a> </li>
-    {{/each}}
+	{{#each campaigns }}
+		<h2>{{ @key }}</h2>
+		<ul>
+			{{#each banners }}
+				<li><a href="{{ bannerlink ../this pagename }}" target="_blank">{{ pagename }}</a></li>
+			{{/each}}
+		</ul>
+	{{/each}}
 </ul>

--- a/webpack/loader.js
+++ b/webpack/loader.js
@@ -14,13 +14,15 @@ Handlebars.registerHelper('bannerlink', function( campaign, bannername ) {
 	return campaign.preview_link.replace( '{{banner}}', bannername );
 });
 
-if ( !currentUrl.query.banner && !currentUrl.query.bannertest ) {	// different wikipedia.org & wikipedia.de banner params
-	$( 'body' ).html( bannerSelectionListTemplate( { campaigns: CAMPAIGNS } ) );
-}
+if ( !currentUrl.query.devbanner ) {
 
-// inject tracking data for current banner.
-// In a compiled banner, the tracking data is baked into the data attribute of the container div.
-if ( currentUrl.query.devbanner ) {
+	$( 'body' ).html( bannerSelectionListTemplate( { campaigns: CAMPAIGNS } ) );
+
+} else {
+
+	// inject tracking data for current banner.
+	// In a compiled banner, the tracking data is baked into the data attribute of the container div.
+
 	const campaigns = new CampaignConfig( CAMPAIGNS );
 	const pages = campaigns.getConfigForPages();
 	const currentBanner = currentUrl.query.devbanner;

--- a/webpack/loader.js
+++ b/webpack/loader.js
@@ -8,7 +8,6 @@ const CampaignConfig = require( './campaign_config' );
 const bannerSelectionListTemplate = require( './banner_selection_list.hbs' );
 
 const currentUrl = url.parse( window.location.href, true );
-const MW_PROTOTYPE_BANNER = 'B17WMDE_webpack_prototype';
 const container = $( '#WMDE-Banner-Container' );
 
 const Handlebars = require('handlebars/runtime');
@@ -22,8 +21,6 @@ function getMediawikiBannerLinksHtml( ) {
 
 if ( !currentUrl.query.banner && !currentUrl.query.bannertest ) {	// different wikipedia.org & wikipedia.de banner params
 	$( 'body' ).html( getMediawikiBannerLinksHtml() );
-} else if ( currentUrl.query.banner === MW_PROTOTYPE_BANNER && !currentUrl.query.devbanner ) {
-	container.html( getMediawikiBannerLinksHtml() );
 }
 
 // inject tracking data for current banner.

--- a/webpack/loader.js
+++ b/webpack/loader.js
@@ -8,19 +8,14 @@ const CampaignConfig = require( './campaign_config' );
 const bannerSelectionListTemplate = require( './banner_selection_list.hbs' );
 
 const currentUrl = url.parse( window.location.href, true );
-const container = $( '#WMDE-Banner-Container' );
 
 const Handlebars = require('handlebars/runtime');
 Handlebars.registerHelper('bannerlink', function( campaign, bannername ) {
 	return campaign.preview_link.replace( '{{banner}}', bannername );
 });
 
-function getMediawikiBannerLinksHtml( ) {
-	return bannerSelectionListTemplate( { campaigns: CAMPAIGNS } );
-}
-
 if ( !currentUrl.query.banner && !currentUrl.query.bannertest ) {	// different wikipedia.org & wikipedia.de banner params
-	$( 'body' ).html( getMediawikiBannerLinksHtml() );
+	$( 'body' ).html( bannerSelectionListTemplate( { campaigns: CAMPAIGNS } ) );
 }
 
 // inject tracking data for current banner.
@@ -29,6 +24,7 @@ if ( currentUrl.query.devbanner ) {
 	const campaigns = new CampaignConfig( CAMPAIGNS );
 	const pages = campaigns.getConfigForPages();
 	const currentBanner = currentUrl.query.devbanner;
+	const container = $( '#WMDE-Banner-Container' );
 	if ( pages[ currentBanner ] ) {
 		console.log( 'current banner', currentBanner, pages[ currentBanner ].tracking, pages[ currentBanner ].campaign_tracking );
 		container.data( 'tracking', pages[ currentBanner ].tracking );
@@ -37,4 +33,3 @@ if ( currentUrl.query.devbanner ) {
 }
 
 // TODO banner loading functions for non-proxied development (with `localbanner` param)
-

--- a/webpack/loader.js
+++ b/webpack/loader.js
@@ -33,10 +33,14 @@ function getMediawikiBannerLinks() {
 	return bannerlist;
 }
 
-if ( !currentUrl.query.banner ) {
-	$( 'body' ).html( bannerSelectionListTemplate( { banners: getMediawikiBannerLinks() } ) );
+function getMediawikiBannerLinksHtml( ) {
+	return bannerSelectionListTemplate( { banners: getMediawikiBannerLinks() } );
+}
+
+if ( !currentUrl.query.banner && !currentUrl.query.bannertest ) {	// different wikipedia.org & wikipedia.de banner params
+	$( 'body' ).html( getMediawikiBannerLinksHtml() );
 } else if ( currentUrl.query.banner === MW_PROTOTYPE_BANNER && !currentUrl.query.devbanner ) {
-	container.html( bannerSelectionListTemplate( { banners: getMediawikiBannerLinks() } ) );
+	container.html( getMediawikiBannerLinksHtml() );
 }
 
 // inject tracking data for current banner.

--- a/webpack/loader.js
+++ b/webpack/loader.js
@@ -11,30 +11,13 @@ const currentUrl = url.parse( window.location.href, true );
 const MW_PROTOTYPE_BANNER = 'B17WMDE_webpack_prototype';
 const container = $( '#WMDE-Banner-Container' );
 
-function getMediawikiBannerLinks() {
-	let bannerlist = [];
-	Object.keys( CAMPAIGNS ).forEach( function ( campaign ) {
-		Object.keys( CAMPAIGNS[ campaign ].banners ).forEach( function ( banner ) {
-			let u = url.parse( url.format( currentUrl ) );
-			u.pathname = '/wiki/Wikipedia:Hauptseite';
-			u.query = u.query || {};
-			u.query.devbanner = CAMPAIGNS[ campaign ].banners[ banner ].pagename;
-			u.query.banner = MW_PROTOTYPE_BANNER;
-			if ( CAMPAIGNS[ campaign ].preview_skin ) {
-				u.query.useskin = CAMPAIGNS[ campaign ].preview_skin;
-			}
-			delete u.search;
-			bannerlist.push( {
-				url: url.format( u ),
-				name: CAMPAIGNS[ campaign ].banners[ banner ].pagename
-			} );
-		} );
-	} );
-	return bannerlist;
-}
+const Handlebars = require('handlebars/runtime');
+Handlebars.registerHelper('bannerlink', function( campaign, bannername ) {
+	return campaign.preview_link.replace( '{{banner}}', bannername );
+});
 
 function getMediawikiBannerLinksHtml( ) {
-	return bannerSelectionListTemplate( { banners: getMediawikiBannerLinks() } );
+	return bannerSelectionListTemplate( { campaigns: CAMPAIGNS } );
 }
 
 if ( !currentUrl.query.banner && !currentUrl.query.bannertest ) {	// different wikipedia.org & wikipedia.de banner params

--- a/wikipedia.de/banner_ctrl.js
+++ b/wikipedia.de/banner_ctrl.js
@@ -1,0 +1,1 @@
+require( './../desktop/banner_ctrl' );

--- a/wikipedia.de/banner_var.js
+++ b/wikipedia.de/banner_var.js
@@ -1,0 +1,1 @@
+require( './../desktop/banner_var' );


### PR DESCRIPTION
* proxy request to wikipedia.de at `/wikipedia.de`, e.g. http://localhost:8084/wikipedia.de?bannertest=Banner/B17WMDE_webpack_prototype&devbanner=B17WMDE_07_170913_ctrl
* less CSS assumptions to work without vector skin, too
* dedicated folder for wikipedia.de (even though they don't have a code diff ATM)
* simplified dev entry point, separated banner lists for different projects
* not influencing banner nodes by [wikipedia.de CSS](https://github.com/wmde/Wikipedia.de/pull/29)
* dev banner loader via GS wiki ([> "Development tool"](https://wiki.wikimedia.de/wiki/Web:Banner)), complete w/ [embarrassing history](https://wiki.wikimedia.de/w/index.php?title=Web:Banner/B17WMDE_webpack_prototype&action=history) of writing JS in wikitext-escaped environment