### PR TITLE
Fix left padding in infobox

### DIFF
--- a/desktop/css/styles.pcss
+++ b/desktop/css/styles.pcss
@@ -44,7 +44,7 @@
 		font-weight: bold;
 		line-height: 1.2em;
 		text-align: left;
-		margin-left: 2em;
+		margin-left: 2rem;
 	}
 
 	@media ( min-width: 1000px ) {
@@ -94,7 +94,7 @@
 	}
 
 	.infobox__footer {
-		padding: 0.025em 0 0 2em;
+		padding: 0.025rem 0 0 2rem;
 
 		background-image: url( 'https://upload.wikimedia.org/wikipedia/donate/9/99/RedInfoI.svg' );
 		background-size: 18px 18px;

--- a/desktop/css/styles_var.pcss
+++ b/desktop/css/styles_var.pcss
@@ -44,7 +44,7 @@
 		font-weight: bold;
 		line-height: 1.2em;
 		text-align: left;
-		margin-left: 2em;
+		margin-left: 2rem;
 	}
 
 	@media ( min-width: 1000px ) {
@@ -94,7 +94,7 @@
 	}
 
 	.infobox__footer {
-		padding: 0.025em 0 0 2em;
+		padding: 0.025rem 0 0 2rem;
 
 		background-image: url( 'https://upload.wikimedia.org/wikipedia/donate/9/99/RedInfoI.svg' );
 		background-size: 18px 18px;


### PR DESCRIPTION
Use rem instead of em to make the padding independent from font size.
This aligns the main text message and the line above the footer.