### PR TITLE
define both search fields to be observed

### DIFF
--- a/shared/skin/minerva.js
+++ b/shared/skin/minerva.js
@@ -8,7 +8,7 @@ module.exports = class Minerva extends Skin {
 		super();
 
 		this.viewport = $( '#mw-mf-viewport' );
-		this.searchField = $( '#searchInput' );
+		this.searchField = $( '#searchInput, input.search' );
 	}
 
 	addSpace( bannerHeight ) {


### PR DESCRIPTION
Following up on #52
In `minerva` there are two search fields, `input.search` is the one on the search overlay. In some cases I could produce some race condition and have the search overlay being displayed before the focus event was defined.

see [phab:T180473](https://phabricator.wikimedia.org/T180473)