### PR TITLE
setup var for test 18

### DIFF
--- a/campaign_info.toml
+++ b/campaign_info.toml
@@ -1,18 +1,18 @@
 # A Campaign with global settings
 [desktop]
-campaign_tracking = "17-ba-171120"
+campaign_tracking = "18-ba-171121"
 preview_link = "/wiki/Wikipedia:Hauptseite?banner=B17WMDE_webpack_prototype&devbanner={{banner}}"
 
 # Banners of the campaign, key after "banners" can be anything
 [desktop.banners.ctrl]
 filename = "./desktop/banner_ctrl.js"
-pagename = "B17WMDE_17_171120_ctrl"
-tracking = "org-17-171120-ctrl"
+pagename = "B17WMDE_18_171121_ctrl"
+tracking = "org-18-171121-ctrl"
 
 [desktop.banners.var]
 filename = "./desktop/banner_var.js"
-pagename = "B17WMDE_17_171120_var"
-tracking = "org-17-171120-var"
+pagename = "B17WMDE_18_171121_var"
+tracking = "org-18-171121-var"
 
 
 # Mobile Campaign

--- a/desktop/banner_var.js
+++ b/desktop/banner_var.js
@@ -3,13 +3,13 @@ require( './css/icons.css' );
 require( './css/wlightbox.css' );
 
 // For A/B testing different styles, load
-// require( './css/styles_var.pcss' );
+require( './css/styles_var.pcss' );
 
 // BEGIN Banner-Specific configuration
 const bannerCloseTrackRatio = 0.01;
 const sizeIssueThreshold = 180;
-const sizeIssueTrackRatio = 1;
-const searchBoxTrackRatio = 1;
+const sizeIssueTrackRatio = 0.01;
+const searchBoxTrackRatio = 0.01;
 const LANGUAGE = 'de';
 const trackingBaseUrl = 'https://tracking.wikimedia.de/piwik.php?idsite=1&rec=1&url=https://spenden.wikimedia.de';
 // END Banner-Specific configuration
@@ -104,16 +104,6 @@ function setupValidationEventHandling() {
 		$( '#WMDE_Banner-frequency' ).addClass( 'select-group--with-error' );
 		addSpaceInstantly();
 	} );
-	banner.on( 'validation:paymenttype:ok', function () {
-		$( '#WMDE_Banner-payment-type-error-text' ).hide();
-		$( '#WMDE_Banner-payment-type' ).removeClass( 'select-group--with-error' );
-		addSpaceInstantly();
-	} );
-	banner.on( 'validation:paymenttype:error', function ( evt, text ) {
-		$( '#WMDE_Banner-payment-type-error-text' ).text( text ).show();
-		$( '#WMDE_Banner-payment-type' ).addClass( 'select-group--with-error' );
-		addSpaceInstantly();
-	} );
 }
 
 function setupAmountEventHandling() {
@@ -171,10 +161,6 @@ $( '#amount-other-input' ).change( function () {
 
 $( '#WMDE_Banner-frequency label' ).on( 'click', function () {
 	BannerFunctions.hideFrequencyError();
-} );
-
-$( '#WMDE_Banner-payment-type label' ).on( 'click', function () {
-	$( this ).trigger( 'paymenttype:selected' );
 } );
 
 BannerFunctions.initializeBannerEvents();

--- a/desktop/css/styles.pcss
+++ b/desktop/css/styles.pcss
@@ -89,6 +89,8 @@
 		flex-direction: row;
 		justify-content: flex-start;
 
+		border-top: 1px solid #990000;
+
 		font-size: 0.8em;
 		line-height: 1.6em;
 	}

--- a/desktop/css/styles_var.pcss
+++ b/desktop/css/styles_var.pcss
@@ -1,0 +1,20 @@
+#WMDE_Banner {
+
+	.form {
+		padding-top: 0;
+		margin-top: 0.4em;
+	}
+
+	.select-group__input:checked + .select-group__state {
+		background: #2a4b8d;
+		border: 1px solid #7d8389;
+		color: #ffffff;
+		outline: 0 none;
+	}
+
+	.button-group__label {
+		color: #3366cc;
+		background: #f8f9fa;
+	}
+
+}

--- a/desktop/templates/banner_html_var.hbs
+++ b/desktop/templates/banner_html_var.hbs
@@ -32,17 +32,21 @@
 			      action="https://spenden.wikimedia.de/donation/new?piwik_campaign={{ CampaignName }}&amp;piwik_kwd={{ BannerName }}&pmt=0">
 				<div id="WMDE_Banner-frequency" class="WMDE-Banner-frequency select-group">
 					<span id="WMDE_Banner-frequency-error-text" class="select-group__errormessage">{{ no-interval-message }}</span>
-					<label class="select-group__option select-group__option--halfwidth">
+					<label class="select-group__option select-group__option--fullwidth">
 						<input type="radio" id="interval_onetime" name="interval" value="0" class="select-group__input">
 						<span class="select-group__state">einmalig</span>
 					</label>
-					<label class="select-group__option select-group__option--halfwidth  donation-frequency-monthly">
+					<label class="select-group__option select-group__option--halfwidth donation-frequency-monthly">
 						<input type="radio" id="interval1" name="interval" value="1" class="select-group__input">
 						<span class="select-group__state">monatlich</span>
 					</label>
 					<label class="select-group__option select-group__option--halfwidth donation-frequency-quarterly">
 						<input type="radio" id="interval3" name="interval" value="3" class="select-group__input">
 						<span class="select-group__state">vierteljährlich</span>
+					</label>
+					<label class="select-group__option select-group__option--halfwidth donation-frequency-biannual">
+						<input type="radio" id="interval6" name="interval" value="6" class="select-group__input">
+						<span class="select-group__state">halbjährlich</span>
 					</label>
 					<label class="select-group__option select-group__option--halfwidth donation-frequency-yearly">
 						<input type="radio" id="interval12" name="interval" value="12" class="select-group__input">
@@ -93,36 +97,21 @@
 					</label>
 				</div>
 
-				<div id="WMDE_Banner-payment-type" class="WMDE-Banner-payment-type select-group">
-					<!--
-						TODO:
-						add message when https://github.com/wmde/fundraising-banners/pull/45 is merge
-					-->
-					<span id="WMDE_Banner-payment-type-error-text" class="select-group__errormessage">{{ no-payment-type-message }}</span>
-					<label class="select-group__option select-group__option--halfwidth">
-						<input type="radio" name="zahlweise" class="select-group__input" value="BEZ">
-						<span class="select-group__state">Lastschrift</span>
-					</label>
+				<div id="WMDE_Banner-payment" class="WMDE-Banner-payment button-group">
+					<button class="button-group__button button-group__button--halfwidth" data-payment-type="BEZ">
+						<span class="button-group__label">Lastschrift</span>
+					</button>
 
-					<label class="select-group__option select-group__option--halfwidth">
-						<input type="radio" name="zahlweise" class="select-group__input" value="UEB">
-						<span class="select-group__state">Überweisung</span>
-					</label>
+					<button class="button-group__button button-group__button--halfwidth" data-payment-type="UEB">
+						<span class="button-group__label">Überweisung</span>
+					</button>
 
-					<label class="select-group__option select-group__option--halfwidth">
-						<input type="radio" name="zahlweise" class="select-group__input" value="MCP">
-						<span class="select-group__state">Kreditkarte</span>
-					</label>
+					<button class="button-group__button button-group__button--halfwidth" data-payment-type="MCP">
+						<span class="button-group__label">Kreditkarte</span>
+					</button>
 
-					<label class="select-group__option select-group__option--halfwidth">
-						<input type="radio" name="zahlweise" class="select-group__input" value="PPL">
-						<span class="select-group__state">PayPal</span>
-					</label>
-				</div>
-
-				<div class="WMDE-Banner-submit button-group">
-					<button class="button-group__button button-group__button--fullwidth">
-						<span class="button-group__label">Weiter, um Spende abzuschließen</span>
+					<button class="button-group__button button-group__button--halfwidth" data-payment-type="PPL">
+						<span class="button-group__label">PayPal</span>
 					</button>
 				</div>
 
@@ -130,6 +119,7 @@
 				<input type="hidden" id="intervalType" name="intervalType" value="0"/>
 				<input type="hidden" id="impCount" name="impCount" value=""/>
 				<input type="hidden" id="bImpCount" name="bImpCount" value=""/>
+				<input type="hidden" id="zahlweise" name="zahlweise" value=""/>
 			</form>
 		</div>
 


### PR DESCRIPTION
- change campaign info
- remove additional general form submit button
- reintroduce payment type options as submit buttons
- tweak layout to look like last year's banner

For this test a historical banner from 2016 was used as VAR.
(see [campaign config](https://meta.wikimedia.org/w/index.php?title=Special:CentralNotice&subaction=noticeDetail&notice=C17_WMDE_Test18))