### PR TITLE
Position remaining amount outside of progress bar

### DIFF
--- a/english/banner_ctrl.js
+++ b/english/banner_ctrl.js
@@ -67,7 +67,8 @@ const progressBarTextInnerLeft = [
 const progressBarTextRight = 'Still missing: <span class="js-value_remaining">1,2</span> Mio. €';
 const progressBar = new ProgressBar( GlobalBannerSettings, campaignProjection, {
 	textInnerLeft: progressBarTextInnerLeft,
-	textRight: progressBarTextRight
+	textRight: progressBarTextRight,
+	modifier: 'progress_bar--lateprogress'
 } );
 const bannerDisplayTimeout = new InterruptibleTimeout();
 

--- a/english/banner_var.js
+++ b/english/banner_var.js
@@ -72,7 +72,8 @@ const progressBarTextInnerLeft = [
 const progressBarTextRight = 'Still missing: <span class="js-value_remaining">1,2</span> Mio. €';
 const progressBar = new ProgressBar( GlobalBannerSettings, campaignProjection, {
 	textInnerLeft: progressBarTextInnerLeft,
-	textRight: progressBarTextRight
+	textRight: progressBarTextRight,
+	modifier: 'progress_bar--lateprogress'
 } );
 const bannerDisplayTimeout = new InterruptibleTimeout();
 

--- a/english/css/styles.pcss
+++ b/english/css/styles.pcss
@@ -294,4 +294,12 @@
 		line-height: 2em;
 	}
 
+	.progress_bar__pointer_tip {
+		margin-top: 18px;
+	}
+
+	.progress_bar__pointer_line {
+		margin-top: 20px;
+	}
+
 }

--- a/mobile/banner_ctrl.js
+++ b/mobile/banner_ctrl.js
@@ -63,7 +63,10 @@ const progressBarTextInnerLeft = [
 	numberOfDaysUntilCampaignEnd > 1 ? Translations[ 'day-plural' ] : Translations[ 'day-singular' ],
 	Translations[ 'suffix-days-left' ]
 ].join( ' ' );
-const progressBar = new ProgressBar( GlobalBannerSettings, campaignProjection, { textInnerLeft: progressBarTextInnerLeft } );
+const progressBar = new ProgressBar( GlobalBannerSettings, campaignProjection, {
+	textInnerLeft: progressBarTextInnerLeft,
+	modifier: 'progress_bar--lateprogress'
+} );
 const bannerDisplayTimeout = new InterruptibleTimeout();
 
 $bannerContainer.html( bannerTemplate( {

--- a/mobile/banner_var.js
+++ b/mobile/banner_var.js
@@ -65,7 +65,10 @@ const progressBarTextInnerLeft = [
 	numberOfDaysUntilCampaignEnd > 1 ? Translations[ 'day-plural' ] : Translations[ 'day-singular' ],
 	Translations[ 'suffix-days-left' ]
 ].join( ' ' );
-const progressBar = new ProgressBar( GlobalBannerSettings, campaignProjection, { textInnerLeft: progressBarTextInnerLeft } );
+const progressBar = new ProgressBar( GlobalBannerSettings, campaignProjection, {
+	textInnerLeft: progressBarTextInnerLeft,
+	modifier: 'progress_bar--lateprogress'
+} );
 const bannerDisplayTimeout = new InterruptibleTimeout();
 
 $bannerContainer.html( bannerTemplate( {

--- a/mobile/css/styles.pcss
+++ b/mobile/css/styles.pcss
@@ -116,14 +116,18 @@
 
 	.progress_bar__donation_remaining--outer {
 		margin-top: 20px;
+		line-height: 2em;
+		font-size: 0.7em;
 	}
 
 	.progress_bar__pointer_tip {
-		margin-top: 18px;
+		margin-top: 15px;
 	}
 
 	.progress_bar__pointer_line {
-		margin-top: 20px;
+		margin-top: 17px;
+		height: 1px;
+		border: 0;
 	}
 
 	@media ( max-width: 400px ) {

--- a/pad/banner_ctrl.js
+++ b/pad/banner_ctrl.js
@@ -64,7 +64,10 @@ const progressBarTextInnerLeft = [
 	numberOfDaysUntilCampaignEnd > 1 ? Translations[ 'day-plural' ] : Translations[ 'day-singular' ],
 	Translations[ 'suffix-days-left' ]
 ].join( ' ' );
-const progressBar = new ProgressBar( GlobalBannerSettings, campaignProjection, { textInnerLeft: progressBarTextInnerLeft } );
+const progressBar = new ProgressBar( GlobalBannerSettings, campaignProjection, {
+	textInnerLeft: progressBarTextInnerLeft,
+	modifier: 'progress_bar--lateprogress'
+} );
 const bannerDisplayTimeout = new InterruptibleTimeout();
 
 $bannerContainer.html( bannerTemplate( {

--- a/pad/banner_var.js
+++ b/pad/banner_var.js
@@ -69,7 +69,10 @@ const progressBarTextInnerLeft = [
 	numberOfDaysUntilCampaignEnd > 1 ? Translations[ 'day-plural' ] : Translations[ 'day-singular' ],
 	Translations[ 'suffix-days-left' ]
 ].join( ' ' );
-const progressBar = new ProgressBar( GlobalBannerSettings, campaignProjection, { textInnerLeft: progressBarTextInnerLeft } );
+const progressBar = new ProgressBar( GlobalBannerSettings, campaignProjection, {
+	textInnerLeft: progressBarTextInnerLeft,
+	modifier: 'progress_bar--lateprogress'
+} );
 const bannerDisplayTimeout = new InterruptibleTimeout();
 
 $bannerContainer.html( bannerTemplate( {

--- a/pad/css/styles.pcss
+++ b/pad/css/styles.pcss
@@ -305,4 +305,14 @@
 		line-height: 2em;
 	}
 
+	.progress_bar__pointer_tip {
+		margin-top: 18px;
+	}
+
+	.progress_bar__pointer_line {
+		margin-top: 20px;
+		height: 1px;
+		border: 0;
+	}
+
 }

--- a/shared/progress_bar/progress_bar.js
+++ b/shared/progress_bar/progress_bar.js
@@ -4,7 +4,7 @@ require( './style.pcss' );
  * Display a progress bar
  *
  * Next refactoring steps:
- * - Set "--lateprogress" modifier depending on the space the "inner" element would need vs the remaining free
+ * - Set "--lateprogress" modifier automatically depending on the space the "inner" element would need vs the remaining free
  *      space inside the progress bar.
  * - Use campaign_days.js from https://github.com/wmde/fundraising-banners/pull/27 to calculate remaining days
  * - Convert to ES2015 class
@@ -19,6 +19,7 @@ function ProgressBar( GlobalBannerSettings, campaignProjection, options ) {
 	this.campaignProjection = campaignProjection;
 	this.options = Object.assign( {
 		minWidth: 90,
+		modifier: '',
 		textRight: 'es fehlen <span class="js-value_remaining">1,2</span> Mio. €',
 		textInnerLeft: ''
 	}, options || {} );
@@ -96,7 +97,8 @@ ProgressBar.prototype.render = function () {
 	return template( {
 		'text-inner-right': '<span class="js-donation_value">0,0</span> Mio. €',
 		'text-inner-left': this.options.textInnerLeft,
-		'text-right': this.options.textRight
+		'text-right': this.options.textRight,
+		'modifier': this.options.modifier
 	} );
 };
 

--- a/shared/progress_bar/template.hbs
+++ b/shared/progress_bar/template.hbs
@@ -1,4 +1,4 @@
-<div class="progress_bar">
+<div class="progress_bar {{ modifier }}">
     <div class="progress_bar__wrapper">
         <div class="progress_bar__donation_fill">
             <div class="progress_bar__days_left">{{{ text-inner-left }}}</div>


### PR DESCRIPTION
It's that time of the year... The message containing the amount that's still needed has to be positioned outside of the progress bar.

The change has already been deployed to all currently running banners.

[phab:T183551](https://phabricator.wikimedia.org/T183551)
