### PR TITLE
Use rimraf package for cleaning up build dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "watch": "webpack --watch",
     "build": "webpack --config webpack.production.js",
     "start": "webpack-dev-server --disable-host-check --host 0.0.0.0",
-    "clean": "rm dist/*.js dist/*.wikitext",
+    "clean": "rimraf dist/*.js dist/*.wikitext",
     "lint:js": "eslint --cache --cache-location .eslintcache --ignore-path .gitignore .",
     "lint:css": "stylelint --syntax scss '**/*.pcss'"
   },
@@ -40,6 +40,7 @@
     "postcss-custom-properties": "^8.0.0",
     "postcss-loader": "^2.1.4",
     "postcss-nested": "^2.1.2",
+    "rimraf": "^2.6.2",
     "sinon": "^4.5.0",
     "style-loader": "^0.18.2",
     "stylelint": "^7.8.0",


### PR DESCRIPTION
While not strictly necessary in our Docker images, it still makes us
more platform-independent. The rimraf package is already a dependency of
other packages, so we're not adding too much code.