### PR TITLE
Progress bar on mobile banner

### DIFF
--- a/mobile/banner_ctrl.js
+++ b/mobile/banner_ctrl.js
@@ -69,6 +69,7 @@ const progressBarTextInnerLeft = [
 	numberOfDaysUntilCampaignEnd > 1 ? Translations[ 'day-plural' ] : Translations[ 'day-singular' ],
 	Translations[ 'suffix-days-left' ]
 ].join( ' ' );
+
 const progressBar = new ProgressBar(
 	{ goalDonationSum: CampaignParameters.donationProjection.goalDonationSum },
 	campaignProjection,

--- a/mobile/banner_ctrl.js
+++ b/mobile/banner_ctrl.js
@@ -61,7 +61,7 @@ const animateHighlight = require( '../shared/animate_highlight' );
 const $bannerContainer = $( '#WMDE-Banner-Container' );
 const CampaignName = $bannerContainer.data( 'campaign-tracking' );
 const BannerName = $bannerContainer.data( 'tracking' );
-const ProgressBar = require( '../shared/progress_bar/progress_bar' );
+const ProgressBar = require( '../shared/progress_bar/progress_bar_mobile' );
 const numberOfDaysUntilCampaignEnd = campaignDays.getNumberOfDaysUntilCampaignEnd();
 const progressBarTextInnerLeft = [
 	Translations[ 'prefix-days-left' ],

--- a/mobile/banner_ctrl.js
+++ b/mobile/banner_ctrl.js
@@ -64,9 +64,9 @@ const BannerName = $bannerContainer.data( 'tracking' );
 const ProgressBar = require( '../shared/progress_bar/progress_bar_mobile' );
 const numberOfDaysUntilCampaignEnd = campaignDays.getNumberOfDaysUntilCampaignEnd();
 const progressBarTextInnerLeft = [
-	Translations[ 'prefix-days-left' ],
+	'noch',
 	numberOfDaysUntilCampaignEnd,
-	numberOfDaysUntilCampaignEnd > 1 ? Translations[ 'day-plural' ] : Translations[ 'day-singular' ],
+	( numberOfDaysUntilCampaignEnd > 1 ? Translations[ 'day-plural' ] : Translations[ 'day-singular' ] ) + ':',
 	Translations[ 'suffix-days-left' ]
 ].join( ' ' );
 

--- a/mobile/banner_var.js
+++ b/mobile/banner_var.js
@@ -61,7 +61,7 @@ const animateHighlight = require( '../shared/animate_highlight' );
 const $bannerContainer = $( '#WMDE-Banner-Container' );
 const CampaignName = $bannerContainer.data( 'campaign-tracking' );
 const BannerName = $bannerContainer.data( 'tracking' );
-const ProgressBar = require( '../shared/progress_bar/progress_bar' );
+const ProgressBar = require( '../shared/progress_bar/progress_bar_mobile' );
 const numberOfDaysUntilCampaignEnd = campaignDays.getNumberOfDaysUntilCampaignEnd();
 const progressBarTextInnerLeft = [
 	Translations[ 'prefix-days-left' ],

--- a/mobile/banner_var.js
+++ b/mobile/banner_var.js
@@ -64,9 +64,9 @@ const BannerName = $bannerContainer.data( 'tracking' );
 const ProgressBar = require( '../shared/progress_bar/progress_bar_mobile' );
 const numberOfDaysUntilCampaignEnd = campaignDays.getNumberOfDaysUntilCampaignEnd();
 const progressBarTextInnerLeft = [
-	Translations[ 'prefix-days-left' ],
+	'noch',
 	numberOfDaysUntilCampaignEnd,
-	numberOfDaysUntilCampaignEnd > 1 ? Translations[ 'day-plural' ] : Translations[ 'day-singular' ],
+	( numberOfDaysUntilCampaignEnd > 1 ? Translations[ 'day-plural' ] : Translations[ 'day-singular' ] ) + ':',
 	Translations[ 'suffix-days-left' ]
 ].join( ' ' );
 const progressBar = new ProgressBar(

--- a/mobile/css/styles.pcss
+++ b/mobile/css/styles.pcss
@@ -139,6 +139,16 @@
 			&__donation_fill {
 				z-index: 5;
 				border-radius: 0;
+				font-size: 12px;
+				line-height: 28px;
+			}
+			&__donation_remaining {
+				font-size: 12px;
+				line-height: 28px;
+			}
+			&__days_left {
+				line-height: 28px;
+				font-size: 12px;
 			}
 			&__wrapper {
 				margin: 0 20px;

--- a/mobile/css/styles.pcss
+++ b/mobile/css/styles.pcss
@@ -134,33 +134,6 @@
 			}
 		}
 
-		.progress_bar {
-			position: relative;
-			&__donation_fill {
-				z-index: 5;
-				border-radius: 0;
-				font-size: 12px;
-				line-height: 28px;
-			}
-			&__donation_remaining {
-				font-size: 12px;
-				line-height: 28px;
-			}
-			&__days_left {
-				line-height: 28px;
-				font-size: 12px;
-			}
-			&__wrapper {
-				margin: 0 20px;
-				font-size: 0.75em;
-				border: 4px solid var( --banner-color-red );
-				border-radius: 4px;
-			}
-			&__donation_text {
-				font-size: 12px;
-			}
-		}
-
 		.infobox {
 			font-size: 20px;
 			line-height: 1.3;

--- a/mobile/css/styles_mini.pcss
+++ b/mobile/css/styles_mini.pcss
@@ -103,33 +103,6 @@
 			color: var( --banner-color-red-light );
 		}
 	}
-
-	.progress_bar {
-		position: relative;
-		&__donation_fill {
-			z-index: 5;
-			border-radius: 0;
-		}
-		&__wrapper {
-			margin: 0 20px;
-			font-size: 0.9em;
-			border: 4px solid var( --banner-color-red );
-			border-radius: 4px;
-		}
-		&__donation_text {
-			font-size: 12px;
-		}
-		&__donation_remaining {
-			&--outer {
-				margin-top: 0;
-				line-height: 2em;
-				position: absolute;
-				top: 7px;
-				font-size: 12px;
-				right: 20px;
-			}
-		}
-	}
 }
 
 /* Mini-banner slider */

--- a/shared/progress_bar/progress_bar_mobile.js
+++ b/shared/progress_bar/progress_bar_mobile.js
@@ -1,0 +1,98 @@
+require( './style.pcss' );
+require( './style_mobile.pcss' );
+
+/**
+ * Display a progress bar
+ *
+ * Next refactoring steps:
+ * - Set "--lateprogress" modifier automatically depending on the space the "inner" element would need vs the remaining free
+ *      space inside the progress bar.
+ * - Use campaign_days.js from https://github.com/wmde/fundraising-banners/pull/27 to calculate remaining days
+ * - Convert to ES2015 class
+ *
+ * @param {object} GlobalBannerSettings
+ * @param {CampaignProjection} campaignProjection
+ * @param {object} options
+ * @constructor
+ */
+function ProgressBar( GlobalBannerSettings, campaignProjection, options ) {
+	this.GlobalBannerSettings = GlobalBannerSettings;
+	this.campaignProjection = campaignProjection;
+	this.options = Object.assign( {
+		minWidth: 90,
+		modifier: '',
+		decimalSeparator: ',',
+		textRight: 'Es fehlen <span class="js-value_remaining">1,2</span> Mio. €',
+		textInnerRight: '<span class="js-donation_value">0</span> Mio. €',
+		textInnerLeft: ''
+	}, options || {} );
+}
+
+ProgressBar.prototype.animate = function () {
+	var decimalSeparator = this.options.decimalSeparator,
+		donationFillElement = $( '.progress_bar__donation_fill' ),
+		donationValueElement = $( '.js-donation_value' ),
+		remainingValueElement = $( '.js-value_remaining' ),
+		donationTarget, donationsCollected, donationsRemaining;
+
+	donationFillElement.clearQueue();
+	donationFillElement.stop();
+
+	donationTarget = this.GlobalBannerSettings.goalDonationSum;
+	donationsCollected = this.campaignProjection.getProjectedDonationSum();
+
+	if ( donationsCollected > donationTarget ) {
+		donationsCollected = donationTarget;
+	}
+	donationsRemaining = donationTarget - donationsCollected;
+
+	donationFillElement.animate(
+		{
+			width: this.getWidthToFill( donationsCollected, donationTarget, donationFillElement.parent().width() )
+		},
+		{
+			duration: 3000,
+			progress: function ( animation, progress ) {
+				var aCollected = donationsCollected * progress,
+					aRemaining = donationTarget - aCollected;
+				remainingValueElement.html( formatMillion( aRemaining, decimalSeparator ) );
+				donationValueElement.html( formatMillion( aCollected, decimalSeparator ) );
+			},
+			complete: function () {
+				remainingValueElement.html( formatMillion( donationsRemaining, decimalSeparator ) );
+				donationValueElement.html( formatMillion( donationsCollected, decimalSeparator ) );
+				$( '.progress_bar' ).addClass( 'progress_bar--finished' );
+			}
+		}
+	);
+};
+
+/**
+ *
+ * @param {Number} donationsCollected
+ * @param {Number} donationsTarget
+ * @param {Number} containerWidth
+ * @return {string} Min width in pixel or fill width in percent
+ */
+ProgressBar.prototype.getWidthToFill = function ( donationsCollected, donationsTarget, containerWidth ) {
+	var widthToFill = ( donationsCollected / donationsTarget ) * 100,
+		barFilled = containerWidth * ( donationsCollected / donationsTarget );
+	return barFilled > this.options.minWidth ? widthToFill + '%' : this.options.minWidth + 'px';
+};
+
+function formatMillion( value, decimalSeparator ) {
+	return ( value / 1000000 ).toFixed( 1 ).replace( '.', decimalSeparator );
+}
+
+ProgressBar.prototype.render = function () {
+	const template = require( './template_mobile.hbs' );
+
+	return template( {
+		'text-inner-right': this.options.textInnerRight,
+		'text-inner-left': this.options.textInnerLeft,
+		'text-right': this.options.textRight,
+		'modifier': this.options.modifier
+	} );
+};
+
+module.exports = ProgressBar;

--- a/shared/progress_bar/style_mobile.pcss
+++ b/shared/progress_bar/style_mobile.pcss
@@ -1,10 +1,32 @@
 .progress_bar__text__above {
 	font-size: 14px;
 	font-weight: bold;
-	line-height: 28px;
+	line-height: 18px;
 	display: flex;
-	flex-direction: row;
-	justify-content: space-around;
-	flex-wrap: nowrap;
+	flex-wrap: wrap;
 	padding: 0 20px;
+
+	@media ( max-width: 350px ) {
+		font-size: 13px;
+	}
+
+	> div {
+		white-space: nowrap;
+	}
+
+	&_left {
+		color: #990000;
+		flex: 1 1 25%;
+		text-align: left;
+	}
+
+	&_right {
+		flex: 1 1 75%;
+		text-align: right;
+
+		@media ( max-width: 450px ) {
+			text-align: left;
+			flex: 1 1 100%;
+		}
+	}
 }

--- a/shared/progress_bar/style_mobile.pcss
+++ b/shared/progress_bar/style_mobile.pcss
@@ -1,0 +1,10 @@
+.progress_bar__text__above {
+	font-size: 14px;
+	font-weight: bold;
+	line-height: 28px;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-around;
+	flex-wrap: nowrap;
+	padding: 0 20px;
+}

--- a/shared/progress_bar/style_mobile.pcss
+++ b/shared/progress_bar/style_mobile.pcss
@@ -1,13 +1,13 @@
 .progress_bar__text__above {
-	font-size: 14px;
+	font-size: 13px;
 	font-weight: bold;
-	line-height: 18px;
+	line-height: 28px;
 	display: flex;
-	flex-wrap: wrap;
+	flex-wrap: nowrap;
 	padding: 0 20px;
 
 	@media ( max-width: 350px ) {
-		font-size: 13px;
+		font-size: 12px;
 	}
 
 	> div {
@@ -23,10 +23,5 @@
 	&_right {
 		flex: 1 1 75%;
 		text-align: right;
-
-		@media ( max-width: 450px ) {
-			text-align: left;
-			flex: 1 1 100%;
-		}
 	}
 }

--- a/shared/progress_bar/template_mobile.hbs
+++ b/shared/progress_bar/template_mobile.hbs
@@ -1,7 +1,6 @@
 <div class="progress_bar__text__above">
-	<div>{{{ text-inner-right }}}</div>
-	<div>{{{ text-inner-left }}} {{{ text-right }}}</div>
-	<div></div>
+	<div class="progress_bar__text__above_left">{{{ text-inner-right }}}</div>
+	<div class="progress_bar__text__above_right">{{{ text-inner-left }}} {{{ text-right }}}</div>
 </div>
 	<div class="progress_bar {{ modifier }}">
 	<div class="progress_bar__wrapper">

--- a/shared/progress_bar/template_mobile.hbs
+++ b/shared/progress_bar/template_mobile.hbs
@@ -1,0 +1,13 @@
+<div class="progress_bar__text__above">
+	<div>{{{ text-inner-right }}}</div>
+	<div>{{{ text-inner-left }}} {{{ text-right }}}</div>
+	<div></div>
+</div>
+	<div class="progress_bar {{ modifier }}">
+	<div class="progress_bar__wrapper">
+		<div class="progress_bar__donation_fill"></div>
+	</div>
+	<div class="progress_bar__donation_remaining progress_bar__donation_remaining--outer">
+		<div class="progress_bar__pointer_tip"></div>
+	</div>
+</div>


### PR DESCRIPTION
Bug: [T211672](https://phabricator.wikimedia.org/T211672)
The text is moved out from the progress bar to the area above it.
It's not super ideal. Still breaks in a second row for `screen width < 335px`

Possible improvements: 
- Shorten the text that says `N days left` 
- Decrease text size to `12px`
- Change `font-style` to normal, instead of bold

