### PR TITLE
Fix webpack configuration for Svelte

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -49,8 +49,38 @@ module.exports = {
 				use: [
 					{ loader: 'handlebars-loader' }
 				]
+			},
+			{
+				test: /\.(html|svelte)$/,
+				exclude: /node_modules/,
+				use: {
+					loader: 'svelte-loader',
+					options: {
+						preprocess: require( 'svelte-preprocess' )( {
+							postcss: {
+								plugins: [
+									require( 'postcss-import' ),
+									require( 'autoprefixer' ),
+									require( 'postcss-nested' ),
+									require( 'postcss-simple-vars' ),
+									require( 'postcss-custom-properties' )( {
+										preserve: false
+									} ),
+									require( 'postcss-combine-duplicated-selectors' )
+								]
+							}
+						} )
+					}
+				}
 			}
 		]
+	},
+	resolve: {
+		alias: {
+			svelte: path.resolve( 'node_modules', 'svelte' )
+		},
+		extensions: [ '.mjs', '.js', '.svelte' ],
+		mainFields: [ 'svelte', 'browser', 'module', 'main' ]
 	},
 	externals: {
 		jquery: 'jQuery'

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -57,18 +57,7 @@ module.exports = {
 					loader: 'svelte-loader',
 					options: {
 						preprocess: require( 'svelte-preprocess' )( {
-							postcss: {
-								plugins: [
-									require( 'postcss-import' ),
-									require( 'autoprefixer' ),
-									require( 'postcss-nested' ),
-									require( 'postcss-simple-vars' ),
-									require( 'postcss-custom-properties' )( {
-										preserve: false
-									} ),
-									require( 'postcss-combine-duplicated-selectors' )
-								]
-							}
+							postcss: true
 						} )
 					}
 				}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,40 +16,6 @@ module.exports = Merge( CommonConfig, {
 			CAMPAIGNS: JSON.stringify( toml.parse( fs.readFileSync( 'campaign_info.toml', 'utf8' ) ) )
 		} )
 	],
-	resolve: {
-		alias: {
-			svelte: path.resolve( 'node_modules', 'svelte' )
-		},
-		extensions: [ '.mjs', '.js', '.svelte' ],
-		mainFields: [ 'svelte', 'browser', 'module', 'main' ]
-	},
-	module: {
-		rules: [
-			{
-				test: /\.(html|svelte)$/,
-				exclude: /node_modules/,
-				use: {
-					loader: 'svelte-loader',
-					options: {
-						preprocess: require( 'svelte-preprocess' )( {
-							postcss: {
-								plugins: [
-									require( 'postcss-import' ),
-									require( 'autoprefixer' ),
-									require( 'postcss-nested' ),
-									require( 'postcss-simple-vars' ),
-									require( 'postcss-custom-properties' )( {
-										preserve: false
-									} ),
-									require( 'postcss-combine-duplicated-selectors' )
-								]
-							}
-						} )
-					}
-				}
-			}
-		]
-	},
 	devServer: {
 		port: 8084,
 		hot: true,


### PR DESCRIPTION
- Move config to shared config file
- Use `postcss.config.js` instead of duplicating settings