### PR TITLE
Add preact-based progress bar to desktop banner

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,7 +14,11 @@ module.exports = {
 			pragma: 'h',
 			pragmaFrag: 'Fragment'
 		} ],
-		'@babel/plugin-proposal-class-properties'
+		'@babel/plugin-proposal-class-properties',
+
+		// TODO Use the webpack configuration to use this plugin only in a production environment.
+		//      Type checks work in dev, but it's iffy
+		'transform-react-remove-prop-types'
 	],
 	exclude: /webpack/
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1760,6 +1760,12 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-transform-react-remove-prop-types": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
+      "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
+      "dev": true
+    },
     "bail": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
@@ -6244,8 +6250,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -6510,7 +6515,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -7191,8 +7195,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -8737,6 +8740,16 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -8886,6 +8899,11 @@
           "dev": true
         }
       }
+    },
+    "react-is": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
+      "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw=="
     },
     "read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "classnames": "^2.2.6",
     "flickity": "^2.2.1",
     "format-number": "^3.0.0",
-    "preact": "^10.0.0"
+    "preact": "^10.0.0",
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "@babel/core": "^7.6.4",
@@ -30,6 +31,7 @@
     "@babel/register": "^7.6.2",
     "autoprefixer": "^7.2.6",
     "babel-loader": "^8.0.6",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "core-js": "^3.3.2",
     "css-loader": "^3.0.0",
     "eslint": "^6.0.1",

--- a/shared/campaign_projection.js
+++ b/shared/campaign_projection.js
@@ -35,3 +35,7 @@ CampaignProjection.prototype.getProjectedRemainingDonationSum = function () {
 CampaignProjection.prototype.getProjectedNumberOfDonors = function () {
 	return calculateProjection( this.campaignDays, this.donorsBase, this.donorsPerMinute );
 };
+
+CampaignProjection.prototype.getRemainingDays = function () {
+	return this.campaignDays.getNumberOfDaysUntilCampaignEnd();
+};

--- a/shared/messages/de.js
+++ b/shared/messages/de.js
@@ -20,7 +20,8 @@ const Translations = {
 	'day-name-st-nicholas-day': 'Nikolaustag',
 	'day-name-christmas-eve': 'Weihnachtsfeiertag',
 	'day-name-christmas-day': '1. Weihnachtsfeiertag',
-	'day-name-2nd-christmas-day': '2. Weihnachtsfeiertag'
+	'day-name-2nd-christmas-day': '2. Weihnachtsfeiertag',
+	'amount-missing': 'Es fehlen'
 };
 
 export default Translations;

--- a/wikipedia.de/banner_ctrl.js
+++ b/wikipedia.de/banner_ctrl.js
@@ -9,6 +9,7 @@ import MatomoTracker from '../shared/matomo_tracker';
 import NullTracker from '../shared/null_tracker';
 import { CampaignProjection } from '../shared/campaign_projection';
 import * as DevGlobalBannerSettings from '../shared/global_banner_settings';
+import formatNumber from 'format-number';
 
 /* These globals are compiled into the banner through the WrapperPlugin, see webpack.common.js */
 /* global CampaignName */
@@ -47,27 +48,25 @@ const campaignProjection = new CampaignProjection(
 		baseDonationSum: GlobalBannerSettings[ 'donations-collected-base' ],
 		donationAmountPerMinute: GlobalBannerSettings[ 'appr-donations-per-minute' ],
 		donorsBase: GlobalBannerSettings[ 'donators-base' ],
-		donorsPerMinute: GlobalBannerSettings[ 'appr-donators-per-minute' ]
+		donorsPerMinute: GlobalBannerSettings[ 'appr-donators-per-minute' ],
+		goalDonationSum: GlobalBannerSettings.goalDonationSum
 	}
 );
-const formatNumber = require( 'format-number' );
+
 const donorFormatter = formatNumber( { round: 0, integerSeparator: '.' } );
 
 render(
 	createElement( Banner, {
 		amountBannerImpressionsInMillion: GlobalBannerSettings[ 'impressions-per-day-in-million' ],
 		numberOfDonors: donorFormatter( campaignProjection.getProjectedNumberOfDonors() ),
-		currentDayName: currentDayName,
-		weekdayPrepPhrase: weekdayPrepPhrase,
-		campaignDaySentence: campaignDaySentence.getSentence(),
+		currentDayName: currentDayName, // TODO Move to Infobox
+		weekdayPrepPhrase: weekdayPrepPhrase, // TODO Move to Infobox
+		campaignDaySentence: campaignDaySentence.getSentence(), // TODO replace with campaignDays, move campaignDaySentence to Infobox
 		campaignName: CampaignName,
 		bannerName: BannerName,
 		trackingData: trackingData,
-		showBanner: '' // TODO use state to generate empty string or 'is-hidden'
+		translations: Translations,
+		locale: LOCALE,
+		campaignProjection
 	} ),
 	document.getElementById( 'WMDE-Banner-Container' ) );
-
-/*
-// TODO use when we have a progress bar
-setTimeout( function () { progressBar.animate(); }, 1000 );
- */

--- a/wikipedia.de/banner_ctrl.js
+++ b/wikipedia.de/banner_ctrl.js
@@ -31,7 +31,7 @@ const trackingData = {
 	bannerCloseTrackRatio: bannerCloseTrackRatio
 };
 
-const LANGUAGE = 'de';
+const LOCALE = 'de';
 const dayName = new DayName( new Date() );
 const currentDayName = Translations[ dayName.getDayNameMessageKey() ];
 const weekdayPrepPhrase = dayName.isSpecialDayName() ? Translations[ 'day-name-prefix-todays' ] : Translations[ 'day-name-prefix-this' ];
@@ -40,7 +40,7 @@ const campaignDays = new CampaignDays(
 	startOfDay( CampaignParameters.startDate ),
 	endOfDay( CampaignParameters.endDate )
 );
-const campaignDaySentence = new CampaignDaySentence( campaignDays, LANGUAGE );
+const campaignDaySentence = new CampaignDaySentence( campaignDays, LOCALE );
 
 const campaignProjection = new CampaignProjection(
 	campaignDays,

--- a/wikipedia.de/banners/Banner.jsx
+++ b/wikipedia.de/banners/Banner.jsx
@@ -1,11 +1,18 @@
 import {Component, h, Fragment } from 'preact';
 import DesktopBanner from './DesktopBanner';
 import MobileBanner from './MobileBanner';
+import TranslationContext from '../components/TranslationContext';
 
 export default class Banner extends Component {
 	constructor(props) {
 		super(props);
 		this.state = { bannerVisible: true }
+	}
+
+	componentDidMount() {
+		if ( this.startAnimation ) {
+			this.startAnimation();
+		}
 	}
 
 	closeBanner = e => {
@@ -14,10 +21,16 @@ export default class Banner extends Component {
 		this.setState( { bannerVisible: false } )
 	};
 
+	setStartAnimation = ( startAnimation ) => {
+		this.startAnimation = startAnimation;
+	};
+
 	render( props, state, context ) {
 		return <Fragment>
-			<DesktopBanner { ...props} closeBanner={this.closeBanner} bannerVisible={this.state.bannerVisible} />
-			<MobileBanner {...props} sliderAutoPlaySpeed={5000} closeBanner={this.closeBanner} bannerVisible={this.state.bannerVisible} />
+			<TranslationContext.Provider value={props.translations}>
+				<DesktopBanner { ...props} closeBanner={this.closeBanner} bannerVisible={this.state.bannerVisible} setStartAnimation={this.setStartAnimation} />
+				<MobileBanner {...props} sliderAutoPlaySpeed={5000} closeBanner={this.closeBanner} bannerVisible={this.state.bannerVisible} />
+			</TranslationContext.Provider>
 		</Fragment>
 	}
 

--- a/wikipedia.de/banners/DesktopBanner.jsx
+++ b/wikipedia.de/banners/DesktopBanner.jsx
@@ -6,8 +6,10 @@ import DonationForm from '../components/DonationForm';
 import Footer from '../components/Footer';
 import Funds from '../components/Funds';
 import Infobox from '../components/Infobox';
+import ProgressBarDesktop from '../components/ProgressBarDesktop';
 
 export default function DesktopBanner( props ) {
+	const campaignProjection = props.campaignProjection;
 	return <div id="WMDE_Banner" className={classNames({'is-hidden': !props.bannerVisible})}>
 		<div className="banner">
 			<div className="banner__content">
@@ -17,6 +19,13 @@ export default function DesktopBanner( props ) {
 							 campaignDaySentence={props.campaignDaySentence}
 							 weekdayPrepPhrase={props.weekdayPrepPhrase}
 							 currentDayName={props.currentDayName}/>
+							 <ProgressBarDesktop
+								 locale={props.locale}
+								 daysLeft={campaignProjection.getRemainingDays()}
+								 donationAmount={campaignProjection.getProjectedDonationSum()}
+								 goalDonationSum={campaignProjection.goalDonationSum}
+								 missingAmount={campaignProjection.getProjectedRemainingDonationSum()}
+								 setStartAnimation={this.props.setStartAnimation} />
 				</div>
 				<DonationForm bannerName={props.bannerName} campaignName={props.campaignName} />
 			</div>

--- a/wikipedia.de/components/ProgressBarDesktop.jsx
+++ b/wikipedia.de/components/ProgressBarDesktop.jsx
@@ -3,6 +3,7 @@ import { Component, h } from 'preact';
 import { useContext } from 'preact/hooks';
 import formatNumber from 'format-number'
 import TranslationContext from './TranslationContext';
+import PropTypes from 'prop-types';
 import style from './ProgressBarDesktop.pcss';
 
 const NOT_STARTED = 0;
@@ -10,22 +11,45 @@ const STARTED = 1;
 const ENDED = 2;
 
 export default class ProgressBarDesktop extends Component {
+	static propTypes = {
+		/** Locale 'EN' or 'DE', defaults to 'EN' */
+		locale: PropTypes.string,
+
+		/** How many days are left in the campaign */
+		daysLeft: PropTypes.number.isRequired,
+
+		/** How many donations have been collected up to this point in time */
+		donationAmount: PropTypes.number.isRequired,
+
+		/** overall donation goal */
+		goalDonationSum: PropTypes.number.isRequired,
+
+		/** Remaining donation goal (could be calculated from sum-amount) */
+		missingAmount: PropTypes.number.isRequired,
+
+		/**
+		 * Function that receives the animation start function as a callback,
+		 * to expose the startAnimation method from this component to parent components.
+		 * See https://stackoverflow.com/a/45582558/130121
+		 */
+		setStartAnimation: PropTypes.func.isRequired,
+	};
+
 	constructor(props) {
 		super(props);
 		this.state = {
 			width: 1,
 			animation: NOT_STARTED
 		};
-		this.millionFormatter = formatNumber( { round: 1, prefix:'€ ', suffix: 'M', padRight: 1 } );
-		if ( props.locale && this.props.locale === 'de' ) {
+		PropTypes.checkPropTypes( ProgressBarDesktop.propTypes, props, 'constructor', 'ProgressBarDesktop' );
+		this.millionFormatter = formatNumber( { round: 1, prefix: '€ ', suffix: 'M', padRight: 1 } );
+		if ( this.props.locale === 'de' ) {
 			this.millionFormatter = formatNumber( { round: 1, decimal: ',', suffix: 'M €', padRight: 1 } );
 		}
 	}
 
 	componentDidMount() {
-		if ( this.props.setStartAnimation ) {
-			this.props.setStartAnimation( this.startAnimation.bind( this ) );
-		}
+		this.props.setStartAnimation( this.startAnimation.bind( this ) );
 	}
 
 	progressAnimationEnded = (e) => {

--- a/wikipedia.de/components/ProgressBarDesktop.jsx
+++ b/wikipedia.de/components/ProgressBarDesktop.jsx
@@ -1,0 +1,71 @@
+import classNames from 'classnames';
+import { Component, h } from 'preact';
+import { useContext } from 'preact/hooks';
+import formatNumber from 'format-number'
+import TranslationContext from './TranslationContext';
+import style from './ProgressBarDesktop.pcss';
+
+const NOT_STARTED = 0;
+const STARTED = 1;
+const ENDED = 2;
+
+export default class ProgressBarDesktop extends Component {
+	constructor(props) {
+		super(props);
+		this.state = {
+			width: 1,
+			animation: NOT_STARTED
+		};
+		this.millionFormatter = formatNumber( { round: 1, prefix:'€ ', suffix: 'M', padRight: 1 } );
+		if ( props.locale && this.props.locale === 'de' ) {
+			this.millionFormatter = formatNumber( { round: 1, decimal: ',', suffix: 'M €', padRight: 1 } );
+		}
+	}
+
+	componentDidMount() {
+		if ( this.props.setStartAnimation ) {
+			this.props.setStartAnimation( this.startAnimation.bind( this ) );
+		}
+	}
+
+	progressAnimationEnded = (e) => {
+		this.setState( { animation: ENDED } )
+	};
+
+	startAnimation() {
+		this.setState( {
+			width: ( this.props.donationAmount * 100 ) / this.props.goalDonationSum,
+			animation: STARTED
+		} );
+	}
+
+	render( props, state) {
+		const getMillion = n => this.millionFormatter( n / 1000000 );
+		const Translations = useContext(TranslationContext);
+		return <div className={classNames( 'progress_bar', {
+			'progress_bar--finished': state.animation === ENDED,
+			'progress_bar--animating': state.animation === STARTED,
+		})}>
+			<div className="progress_bar__wrapper">
+				<div className="progress_bar__donation_fill" style={ `width:${state.width}%` } onTransitionEnd={this.progressAnimationEnded}>
+					<div className="progress_bar__days_left">
+						{Translations['prefix-days-left']}{ ' ' }
+						{ props.daysLeft } { ' ' }
+						{ props.daysLeft === 1 ? Translations['days-singular'] : Translations['days-plural'] }
+					</div>
+					<div className="progress_bar__donation_text">{ getMillion( props.donationAmount ) }</div>
+				</div>
+				<div
+					className="progress_bar__donation_remaining progress_bar__donation_remaining--inner">
+					{ Translations['amount-missing'] }{ ' ' }
+					{ getMillion( props.missingAmount ) }
+				</div>
+			</div>
+			<div className="progress_bar__donation_remaining progress_bar__donation_remaining--outer">
+				<div className="progress_bar__pointer_tip"></div>
+				<hr className="progress_bar__pointer_line" />
+					Es fehlen { props.missingAmount }M €
+			</div>
+		</div>
+	}
+}

--- a/wikipedia.de/components/ProgressBarDesktop.pcss
+++ b/wikipedia.de/components/ProgressBarDesktop.pcss
@@ -1,0 +1,114 @@
+.progress_bar {
+	display: flex;
+}
+
+.progress_bar__wrapper {
+	position: relative;
+	margin: 4px 35px;
+	border: 2px solid #990000;
+	border-radius: 8px;
+	display: flex;
+	justify-content: space-between;
+	flex: 1;
+}
+
+.progress_bar__donation_fill {
+	width: 0;
+	height: 28px;
+	background: #990000;
+	border-radius: 5px 16px 16px 5px;
+	display: flex;
+	justify-content: space-between;
+	transition-duration: 3000ms;
+	transition-property: all;
+}
+
+.progress_bar__donation_text {
+	text-align: right;
+	line-height: 28px;
+	font-size: 0.9em;
+	font-weight: bold;
+	color: #ffffff;
+	overflow: hidden;
+	padding-right: 16px;
+	flex: 1;
+	visibility: hidden;
+}
+
+.progress_bar__donation_remaining {
+	padding: 0 10px;
+	text-align: right;
+	font-size: 0.9em;
+	color: #000000;
+	font-weight: bold;
+	line-height: 28px;
+	visibility: hidden;
+	white-space: nowrap;
+}
+
+.progress_bar__donation_remaining--outer {
+	display: none;
+	position: relative;
+	line-height: 40px;
+	font-size: 0.9em;
+	color: #000000;
+	font-weight: bold;
+}
+
+.progress_bar__pointer_tip {
+	width: 5px;
+	height: 5px;
+	background: #000000;
+	float: left;
+	border-radius: 100%;
+	margin-top: 7px;
+}
+
+.progress_bar__pointer_line {
+	float: left;
+	width: 25px;
+	background: #000000;
+	margin: 9px 2px 0 0;
+}
+
+.progress_bar__days_left {
+	visibility: hidden;
+	font-size: 0.9em;
+	color: #ffffff;
+	font-weight: bold;
+	line-height: 36px;
+	padding-left: 5px;
+}
+
+.progress_bar--finished {
+	.progress_bar__days_left,
+	.progress_bar__donation_text,
+	.progress_bar__donation_remaining {
+		visibility: visible;
+	}
+}
+
+@media ( max-width: 600px ) {
+	.progress_bar__days_left,
+	.progress_bar--finished .progress_bar__days_left {
+		display: none;
+	}
+}
+
+.progress_bar--lateprogress {
+	.progress_bar__donation_remaining--inner {
+		display: none;
+	}
+
+	.progress_bar__donation_remaining--outer {
+		display: block;
+	}
+
+	.progress_bar__wrapper {
+		margin-right: -16px;
+	}
+
+	.progress_bar__donation_fill {
+		margin-right: 16px;
+	}
+}

--- a/wikipedia.de/components/TranslationContext.js
+++ b/wikipedia.de/components/TranslationContext.js
@@ -1,0 +1,4 @@
+import { createContext } from 'preact/compat';
+import Translations from '../../shared/messages/de';
+
+export default createContext( Translations );


### PR DESCRIPTION
Add getRemainingDays method to CampaignProjection
Add Progress Bar component for Desktop (might be turned into a mobile
one later).
Add TranslationContext for passing around translations.
Add TODOs for optimizing the Infobox component and reducing the amount
of code in banner_ctrl.js

The progress bar animation is trigged by a callback from the banner.
The progress bar animation is done via CSS transitions.