### PR TITLE
Make Matomo tracker asynchronous

### DIFF
--- a/test/matomo_tracker_test.js
+++ b/test/matomo_tracker_test.js
@@ -1,0 +1,69 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import MatomoTracker from '../shared/matomo_tracker';
+
+describe( 'MatomoTracker', function () {
+
+	const TRACK_RATIO_ALWAYS = 1;
+
+	beforeEach( () => {
+		global.window = { TestTracker: undefined };
+	} );
+
+	it( 'records impressions', () => {
+		window.TestTracker = {
+			trackContentImpression: sinon.spy()
+		};
+		const tracker = new MatomoTracker( 'TestTracker', 'TestBanner05' );
+
+		tracker.recordBannerImpression();
+
+		assert.ok( window.TestTracker.trackContentImpression.calledWith( 'Banners', 'banner-shown', 'TestBanner05' ) );
+	} );
+
+	it( 'tracks events', () => {
+		window.TestTracker = {
+			trackEvent: sinon.spy()
+		};
+		const tracker = new MatomoTracker( 'TestTracker', 'TestBanner05' );
+
+		tracker.trackEvent( 'some-action', TRACK_RATIO_ALWAYS );
+
+		assert.ok( window.TestTracker.trackEvent.calledWith( 'Banners', 'some-action', 'TestBanner05' ) );
+	} );
+
+	it( 'collects tracking events until the tracker becomes available', ( done ) => {
+		const retryInterval = 5;
+		const simulatedLoadTime = 10;
+		const scheduleRetry = tracker => {
+			setTimeout( tracker.waitForTrackerToInit.bind( tracker ), retryInterval );
+		};
+		const tracker = new MatomoTracker( 'TestTracker', 'TestBanner05', scheduleRetry );
+		tracker.recordBannerImpression();
+		tracker.trackEvent( 'some-action', TRACK_RATIO_ALWAYS );
+
+		setTimeout( () => {
+			window.TestTracker = {
+				trackContentImpression: sinon.spy(),
+				trackEvent: sinon.spy()
+			};
+		}, simulatedLoadTime );
+
+		setTimeout( () => {
+			assert.ok( window.TestTracker.trackContentImpression.calledWith( 'Banners', 'banner-shown', 'TestBanner05' ) );
+			assert.ok( window.TestTracker.trackEvent.calledWith( 'Banners', 'some-action', 'TestBanner05' ) );
+			done();
+		}, retryInterval + simulatedLoadTime + 1 );
+	} );
+
+	it( 'aborts trying to find the tracker after 10 tries', () => {
+		// An immediate scheduler
+		const scheduleRetry = tracker => {
+			tracker.waitForTrackerToInit();
+		};
+		const tracker = new MatomoTracker( 'TestTracker', 'TestBanner05', scheduleRetry );
+
+		assert.strictEqual( tracker.trackerFindCounter, 10 );
+	} );
+
+} );

--- a/wikipedia.de/banner_ctrl.js
+++ b/wikipedia.de/banner_ctrl.js
@@ -6,24 +6,18 @@ import CampaignDays, { startOfDay, endOfDay } from '../shared/campaign_days';
 import CampaignDaySentence from '../shared/campaign_day_sentence';
 import { createCampaignParameters } from '../shared/campaign_parameters';
 import MatomoTracker from '../shared/matomo_tracker';
-import NullTracker from '../shared/null_tracker';
 import { CampaignProjection } from '../shared/campaign_projection';
 import * as DevGlobalBannerSettings from '../shared/global_banner_settings';
 
 /* These globals are compiled into the banner through the WrapperPlugin, see webpack.common.js */
 /* global CampaignName */
 /* global BannerName */
-/* global _paq */
 
 const GlobalBannerSettings = window.GlobalBannerSettings || DevGlobalBannerSettings;
 const bannerClickTrackRatio = 1; // TODO FOR TESTING
 const bannerCloseTrackRatio = 1; // TODO FOR TESTING
-let eventTracker;
-if ( typeof _paq === 'undefined' ) {
-	eventTracker = new NullTracker( BannerName );
-} else {
-	eventTracker = new MatomoTracker( _paq, BannerName );
-}
+const eventTracker = new MatomoTracker( 'FundraisingTracker', BannerName );
+
 const trackingData = {
 	eventTracker: eventTracker,
 	bannerClickTrackRatio: bannerClickTrackRatio,


### PR DESCRIPTION
Since the tracker library is loaded asnychronously, we need to store
the track events until it becomes available.