### PR TITLE
Use matomo tracker for impression counting

### DIFF
--- a/shared/matomo_tracker.js
+++ b/shared/matomo_tracker.js
@@ -15,7 +15,7 @@ export default class MatomoTracker {
 		this.tracker = null;
 		this.trackerName = trackerName;
 		this.trackerFindCounter = 0;
-		if ( !this.trackerLibrayIsLoaded( trackerName ) ) {
+		if ( !this.trackerLibraryIsLoaded( trackerName ) ) {
 			scheduleRetry( this );
 			return;
 		}
@@ -34,12 +34,12 @@ export default class MatomoTracker {
 		trackFn( this.tracker );
 	}
 
-	trackerLibrayIsLoaded( trackerName ) {
+	trackerLibraryIsLoaded( trackerName ) {
 		return typeof window[ trackerName ] !== 'undefined' && window[ trackerName ] !== null;
 	}
 
 	waitForTrackerToInit() {
-		if ( !this.trackerLibrayIsLoaded( this.trackerName ) ) {
+		if ( !this.trackerLibraryIsLoaded( this.trackerName ) ) {
 			this.trackerFindCounter++;
 			if ( this.trackerFindCounter < 10 ) {
 				this.scheduleRetry( this );

--- a/wikipedia.de/banner_ctrl.js
+++ b/wikipedia.de/banner_ctrl.js
@@ -64,3 +64,4 @@ render(
 		campaignProjection
 	} ),
 	document.getElementById( 'WMDE-Banner-Container' ) );
+eventTracker.recordBannerImpression();


### PR DESCRIPTION
Use matomo tracker for impression counting in the wikipedia.de banner.

Fix method name in tracker.

Followup to #256 