### PR TITLE
Avoid sourcemaps in production

### DIFF
--- a/webpack.production.js
+++ b/webpack.production.js
@@ -2,5 +2,6 @@ const Merge = require( 'webpack-merge' );
 const CommonConfig = require( './webpack.common.js' );
 
 module.exports = Merge( CommonConfig, {
+	devtool: false,
 	mode: 'production'
 } );


### PR DESCRIPTION
Since we don't deploy the sourcemaps, we need to suppress the sourcemap
generation in the production environemnt to avoid unneccessary requests.