### PR TITLE
Move MediawikiTextWrapper to production config

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -2,18 +2,12 @@ const path = require( 'path' );
 const fs = require( 'fs' );
 const toml = require( 'toml' );
 const webpack = require( 'webpack' );
-const MediaWikiTextWrapper = require( './webpack/mediawiki_text_wrapper' );
-const CampaignConfig = require( './webpack/campaign_config' );
 const WrapperPlugin = require( 'wrapper-webpack-plugin' );
 
+const CampaignConfig = require( './webpack/campaign_config' );
 const campaigns = new CampaignConfig( toml.parse( fs.readFileSync( 'campaign_info.toml', 'utf8' ) ) );
 
-function readWrapperTemplate( name ) {
-	return fs.readFileSync( './webpack/wikitext_templates/' + name + '.hbs', 'utf8' );
-}
-
 module.exports = {
-	devtool: 'sourcemap',
 	entry: campaigns.getEntryPoints(),
 	output: {
 		filename: '[name].js',
@@ -67,15 +61,6 @@ module.exports = {
 	plugins: [
 		new webpack.ProvidePlugin( {
 			jQuery: 'jquery'
-		} ),
-		new MediaWikiTextWrapper( {
-			templates: campaigns.getWrapperTemplates( readWrapperTemplate ),
-			context: {
-				bannerValuesJS: '{{MediaWiki:WMDE_FR2017/Resources/BannerValues.js}}',
-				bannerValues: '{{MediaWiki:WMDE_Fundraising/Campaign_Parameters_2019}}'
-			},
-			filePattern: '{B,WMDE}*.js',
-			campaignConfig: campaigns.getConfigForPages()
 		} ),
 		new WrapperPlugin( {
 			test: /B\d{2}WPDE.*.js$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const CommonConfig = require( './webpack.common.js' );
 const webpack = require( 'webpack' );
 
 module.exports = Merge( CommonConfig, {
+	devtool: 'source-map',
 	mode: 'development',
 	entry: {
 		loader: './webpack/loader.js'

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -1,7 +1,28 @@
+const fs = require( 'fs' );
+const toml = require( 'toml' );
 const Merge = require( 'webpack-merge' );
 const CommonConfig = require( './webpack.common.js' );
+const MediaWikiTextWrapper = require( './webpack/mediawiki_text_wrapper' );
+
+const CampaignConfig = require( './webpack/campaign_config' );
+const campaigns = new CampaignConfig( toml.parse( fs.readFileSync( 'campaign_info.toml', 'utf8' ) ) );
+
+function readWrapperTemplate( name ) {
+	return fs.readFileSync( './webpack/wikitext_templates/' + name + '.hbs', 'utf8' );
+}
 
 module.exports = Merge( CommonConfig, {
 	devtool: false,
-	mode: 'production'
+	mode: 'production',
+	plugins: [
+		new MediaWikiTextWrapper( {
+			templates: campaigns.getWrapperTemplates( readWrapperTemplate ),
+			context: {
+				bannerValuesJS: '{{MediaWiki:WMDE_FR2017/Resources/BannerValues.js}}',
+				bannerValues: '{{MediaWiki:WMDE_Fundraising/Campaign_Parameters_2019}}'
+			},
+			filePattern: '{B,WMDE}*.js',
+			campaignConfig: campaigns.getConfigForPages()
+		} )
+	]
 } );


### PR DESCRIPTION
The MediawikiTextWrapper webpack plugin wraps the JavaScript generated by
Webpack in WikiText that can be pasted in CentralNotice. Since commit
88ee3d48f2c0810b73e7f67eaf71cbca20cc9b1b it suppresses the JavaScript
files that will be written, to keep the build directory clean.

This commit moves the MediawikiTextWrapper to the webpack production
configuration setup, because the development environment uses the
JavaScript files generated by Webpack.

A followup to #295 