### PR TITLE
Fix mobile banners

### DIFF
--- a/mobile_english_preact/Banner.jsx
+++ b/mobile_english_preact/Banner.jsx
@@ -22,6 +22,7 @@ export default class Banner extends Component {
 		};
 		this.transitionToFullpage = () => {};
 		this.startHighlight = () => {};
+		this.adjustFollowupBannerHeight = () => {};
 	}
 
 	miniBannerTransitionRef = createRef();
@@ -71,6 +72,11 @@ export default class Banner extends Component {
 	registerBannerTransition = cb => { this.slideInBanner = cb; };
 	registerFullpageBannerTransition = cb => { this.transitionToFullpage = cb; };
 	registerStartHighlight = cb => { this.startHighlight = cb; };
+	registerAdjustFollowupBannerHeight = cb => { this.adjustFollowupBannerHeight = cb; };
+	onMiniBannerSlideInFinished = () => {
+		this.bannerSlider.enableAutoplay();
+		this.adjustFollowupBannerHeight( this.miniBannerTransitionRef.current.getHeight() );
+	};
 
 	// eslint-disable-next-line no-unused-vars
 	render( props, state, context ) {
@@ -86,7 +92,7 @@ export default class Banner extends Component {
 				<BannerTransition
 					fixed={ true }
 					registerDisplayBanner={ this.registerBannerTransition }
-					onFinish={ () => this.bannerSlider.enableAutoplay() }
+					onFinish={ this.onMiniBannerSlideInFinished }
 					skinAdjuster={ props.skinAdjuster }
 					ref={this.miniBannerTransitionRef}
 				>
@@ -100,10 +106,11 @@ export default class Banner extends Component {
 				</BannerTransition>
 				<FollowupTransition
 					registerDisplayBanner={ this.registerFullpageBannerTransition }
+					registerFirstBannerFinished={ this.registerAdjustFollowupBannerHeight }
 					onFinish={ () => { this.startHighlight(); } }
-					previousTransition={ this.miniBannerTransitionRef }
 					transitionDuration={ 1250 }
 					skinAdjuster={ props.skinAdjuster }
+					hasStaticParent={ false }
 				>
 					<FullpageBanner
 						{...props}

--- a/mobile_english_preact/components/FullpageBanner.jsx
+++ b/mobile_english_preact/components/FullpageBanner.jsx
@@ -10,8 +10,8 @@ export default class FullpageBanner extends Component {
 	render( props ) {
 		const campaignProjection = props.campaignProjection;
 		const trackingParams = `piwik_campaign=${props.campaignName}&piwik_kwd=${props.bannerName}_link`;
-		return <div className={ classNames( 'frbanner', { visible: props.isFullPageVisible && props.bannerVisible } ) }>
-			<div className="frbanner-window">
+		return <div className={ classNames( 'fullpage-banner', { visible: props.isFullPageVisible && props.bannerVisible } ) }>
+			<div className="fullpage-banner__info">
 				<header className="headline">
 					<div className="headline__container">
 						<span className="headline__content">the wikimedia fundraising campaign</span>

--- a/mobile_english_preact/styles/FullpageBanner.pcss
+++ b/mobile_english_preact/styles/FullpageBanner.pcss
@@ -1,6 +1,6 @@
 .wmde-banner {
 
-	.frbanner {
+	.fullpage-banner {
 		background: $color-primary-lighter;
 		width: 98%;
 		box-shadow: 0 7px 22px 0 rgba( 0, 0, 0, 0.35 );
@@ -19,7 +19,7 @@
 		display: block;
 		cursor: pointer;
 		position: absolute;
-		right: 1%; /* match the 1% gap on the right side of .frbanner */
+		right: 1%; /* match the 1% gap on the right side of .fullpage-banner */
 		top: 0;
 		opacity: 0.6;
 		text-indent: -99999px;
@@ -34,7 +34,7 @@
 		}
 	}
 
-	.frbanner-window {
+	.fullpage-banner__info {
 		.headline {
 			cursor: default;
 			width: 85%;

--- a/mobile_english_preact/styles/styles_ctrl.pcss
+++ b/mobile_english_preact/styles/styles_ctrl.pcss
@@ -1,6 +1,7 @@
 @import 'variables.pcss';
 
 @import '../../shared/components/BannerTransition.pcss';
+@import '../../shared/components/FollowupTransition.pcss';
 
 @import './Banner.pcss';
 @import './MiniBanner.pcss';

--- a/mobile_preact/Banner.jsx
+++ b/mobile_preact/Banner.jsx
@@ -22,6 +22,7 @@ export default class Banner extends Component {
 		};
 		this.transitionToFullpage = () => {};
 		this.startHighlight = () => {};
+		this.adjustFollowupBannerHeight = () => {};
 	}
 
 	miniBannerTransitionRef = createRef();
@@ -71,6 +72,11 @@ export default class Banner extends Component {
 	registerBannerTransition = cb => { this.slideInBanner = cb; };
 	registerFullpageBannerTransition = cb => { this.transitionToFullpage = cb; };
 	registerStartHighlight = cb => { this.startHighlight = cb; };
+	registerAdjustFollowupBannerHeight = cb => { this.adjustFollowupBannerHeight = cb; };
+	onMiniBannerSlideInFinished = () => {
+		this.bannerSlider.enableAutoplay();
+		this.adjustFollowupBannerHeight( this.miniBannerTransitionRef.current.getHeight() );
+	};
 
 	// eslint-disable-next-line no-unused-vars
 	render( props, state, context ) {
@@ -86,7 +92,7 @@ export default class Banner extends Component {
 				<BannerTransition
 					fixed={ true }
 					registerDisplayBanner={ this.registerBannerTransition }
-					onFinish={ () => this.bannerSlider.enableAutoplay() }
+					onFinish={ this.onMiniBannerSlideInFinished }
 					skinAdjuster={ props.skinAdjuster }
 					ref={this.miniBannerTransitionRef}
 				>
@@ -100,10 +106,11 @@ export default class Banner extends Component {
 				</BannerTransition>
 				<FollowupTransition
 					registerDisplayBanner={ this.registerFullpageBannerTransition }
+					registerFirstBannerFinished={ this.registerAdjustFollowupBannerHeight }
 					onFinish={ () => { this.startHighlight(); } }
-					previousTransition={ this.miniBannerTransitionRef }
 					transitionDuration={ 1250 }
 					skinAdjuster={ props.skinAdjuster }
+					hasStaticParent={ false }
 				>
 					<FullpageBanner
 						{...props}

--- a/mobile_preact/components/FullpageBanner.jsx
+++ b/mobile_preact/components/FullpageBanner.jsx
@@ -10,8 +10,8 @@ export default class FullpageBanner extends Component {
 	render( props ) {
 		const campaignProjection = props.campaignProjection;
 		const trackingParams = `piwik_campaign=${props.campaignName}&piwik_kwd=${props.bannerName}_link`;
-		return <div className={ classNames( 'frbanner', { visible: props.isFullPageVisible && props.bannerVisible } ) }>
-			<div className="frbanner-window">
+		return <div className={ classNames( 'fullpage-banner', { visible: props.isFullPageVisible && props.bannerVisible } ) }>
+			<div className="fullpage-banner__info">
 				<div className="close" onClick={ props.onClose }/>
 				<Infobox
 					formatters={props.formatters}

--- a/mobile_preact/styles/FullpageBanner.pcss
+++ b/mobile_preact/styles/FullpageBanner.pcss
@@ -1,6 +1,6 @@
 .wmde-banner {
 
-	.frbanner {
+	.fullpage-banner {
 		background: $color-primary-lighter;
 		width: 98%;
 		box-shadow: 0 7px 22px 0 rgba( 0, 0, 0, 0.35 );
@@ -13,7 +13,7 @@
 		padding-bottom: 15px;
 	}
 
-	.frbanner-window {
+	.fullpage-banner__info {
 		border: 5px solid $color-primary;
 	}
 
@@ -22,7 +22,7 @@
 		display: block;
 		cursor: pointer;
 		position: absolute;
-		right: 1%; /* match the 1% gap on the right side of .frbanner */
+		right: 1%; /* match the 1% gap on the right side of .fullpage-banner */
 		top: 0;
 		opacity: 0.6;
 		text-indent: -99999px;

--- a/mobile_preact/styles/styles_ctrl.pcss
+++ b/mobile_preact/styles/styles_ctrl.pcss
@@ -1,6 +1,7 @@
 @import 'variables.pcss';
 
 @import '../../shared/components/BannerTransition.pcss';
+@import '../../shared/components/FollowupTransition.pcss';
 
 @import './Banner.pcss';
 @import './MiniBanner.pcss';

--- a/shared/components/BannerTransition.jsx
+++ b/shared/components/BannerTransition.jsx
@@ -40,6 +40,10 @@ export default class BannerTransition extends Component {
 		this.setState( { transitionPhase: READY } );
 	}
 
+	getHeight() {
+		return this.ref.current ? this.ref.current.offsetHeight : 0;
+	}
+
 	displayBanner = () => {
 		this.setState( { transitionPhase: SLIDING } );
 		this.props.skinAdjuster.addSpace( this.ref.current.offsetHeight, this.transition );

--- a/shared/components/BannerTransition.pcss
+++ b/shared/components/BannerTransition.pcss
@@ -7,6 +7,7 @@
 
 .banner-position {
 	position: absolute;
+	left: 0;
 	width: 100%;
 	z-index: 10000;
 }

--- a/shared/components/FollowupTransition.pcss
+++ b/shared/components/FollowupTransition.pcss
@@ -1,0 +1,6 @@
+.followup-banner-position {
+	position: absolute;
+	left: 0;
+	width: 100%;
+	z-index: 19999;
+}

--- a/shared/skin/minerva.js
+++ b/shared/skin/minerva.js
@@ -39,10 +39,6 @@ export default class Minerva extends Skin {
 		$( '#ca-ve-edit, .mw-editsection-visualeditor' ).click( onEdit );
 	}
 
-	moveBannerContainerToTopOfDom() {
-		$( 'body' ).prepend( $( '#centralNotice' ) );
-	}
-
 	getSizeIssueThreshold() {
 		return 180;
 	}


### PR DESCRIPTION
Safari mobile crashes on close when the Minerva SkinAdjuster moves the
banner element to the top of the DOM.

This change adapts the Transition elements to be sgtill absoluetly
positioned, but inside a relatively positioned parent element,
whose "top" position is changed by skinAdjuster. To keep the 2-phase
animation, the FollowupTransition must have a negative top offset that
corresponds to the positive top offset of its parent element. That way,
it will always stay at position 0. It also needs to incorporate the
previous offset of the mini banner.

Renamed "frbanner" to "fullpage-banner" to properly show and hide the 2
banners depending on state and to have more semantic names.