### PR TITLE
Fix for mobile banner space miscalculation

### DIFF
--- a/mobile_english_preact/Banner.jsx
+++ b/mobile_english_preact/Banner.jsx
@@ -23,9 +23,11 @@ export default class Banner extends Component {
 		this.transitionToFullpage = () => {};
 		this.startHighlight = () => {};
 		this.adjustFollowupBannerHeight = () => {};
+		this.fullPageBannerReRender = () => {};
 	}
 
 	miniBannerTransitionRef = createRef();
+	fullBannerTransitionRef = createRef();
 
 	componentDidMount() {
 		this.bannerSlider = new Slider( this.props.sliderAutoPlaySpeed );
@@ -38,6 +40,22 @@ export default class Banner extends Component {
 				this.slideInBanner();
 			}
 		);
+
+		this.props.registerResizeBanner( this.onPageResize.bind( this ) );
+	}
+
+	onPageResize() {
+		if ( this.state.displayState !== VISIBLE ) {
+			return;
+		}
+
+		if ( this.state.isFullPageVisible ) {
+			this.props.skinAdjuster.addSpaceInstantly( this.getFullBannerHeight() );
+			this.fullPageBannerReRender();
+		} else {
+			this.bannerSlider.resize();
+			this.props.skinAdjuster.addSpaceInstantly( this.getMiniBannerHeight() );
+		}
 	}
 
 	// eslint-disable-next-line no-unused-vars
@@ -49,10 +67,17 @@ export default class Banner extends Component {
 			this.props.trackingData.bannerClickTrackRatio
 		);
 		window.scrollTo( 0, 0 );
-		const miniBannerHeight = this.miniBannerTransitionRef.current ? this.miniBannerTransitionRef.current.base.offsetHeight : 0;
-		this.transitionToFullpage( miniBannerHeight );
+		this.transitionToFullpage( this.getMiniBannerHeight() );
 		this.setState( { isFullPageVisible: true } );
 	};
+
+	getMiniBannerHeight() {
+		return this.miniBannerTransitionRef.current ? this.miniBannerTransitionRef.current.base.offsetHeight : 0;
+	}
+
+	getFullBannerHeight() {
+		return this.fullBannerTransitionRef.current ? this.fullBannerTransitionRef.current.base.offsetHeight : 0;
+	}
 
 	closeBanner = e => {
 		this.props.trackingData.tracker.trackBannerEvent(
@@ -73,6 +98,7 @@ export default class Banner extends Component {
 	registerFullpageBannerTransition = cb => { this.transitionToFullpage = cb; };
 	registerStartHighlight = cb => { this.startHighlight = cb; };
 	registerAdjustFollowupBannerHeight = cb => { this.adjustFollowupBannerHeight = cb; };
+	registerFullPageBannerReRender = cb => { this.fullPageBannerReRender = cb; };
 	onMiniBannerSlideInFinished = () => {
 		this.bannerSlider.enableAutoplay();
 		this.adjustFollowupBannerHeight( this.miniBannerTransitionRef.current.getHeight() );
@@ -107,10 +133,12 @@ export default class Banner extends Component {
 				<FollowupTransition
 					registerDisplayBanner={ this.registerFullpageBannerTransition }
 					registerFirstBannerFinished={ this.registerAdjustFollowupBannerHeight }
+					registerFullPageBannerReRender={ this.registerFullPageBannerReRender }
 					onFinish={ () => { this.startHighlight(); } }
 					transitionDuration={ 1250 }
 					skinAdjuster={ props.skinAdjuster }
 					hasStaticParent={ false }
+					ref={this.fullBannerTransitionRef}
 				>
 					<FullpageBanner
 						{...props}

--- a/mobile_english_preact/Banner.jsx
+++ b/mobile_english_preact/Banner.jsx
@@ -2,6 +2,7 @@
 import { Component, h, createRef } from 'preact';
 import classNames from 'classnames';
 import { Slider } from '../shared/banner_slider';
+import debounce from '../shared/debounce';
 
 import BannerTransition from '../shared/components/BannerTransition';
 import MiniBanner from './components/MiniBanner';
@@ -41,7 +42,7 @@ export default class Banner extends Component {
 			}
 		);
 
-		this.props.registerResizeBanner( this.onPageResize.bind( this ) );
+		this.props.registerResizeBanner( debounce( this.onPageResize.bind( this ), 200 ) );
 	}
 
 	onPageResize() {

--- a/mobile_preact/Banner.jsx
+++ b/mobile_preact/Banner.jsx
@@ -23,9 +23,11 @@ export default class Banner extends Component {
 		this.transitionToFullpage = () => {};
 		this.startHighlight = () => {};
 		this.adjustFollowupBannerHeight = () => {};
+		this.fullPageBannerReRender = () => {};
 	}
 
 	miniBannerTransitionRef = createRef();
+	fullBannerTransitionRef = createRef();
 
 	componentDidMount() {
 		this.bannerSlider = new Slider( this.props.sliderAutoPlaySpeed );
@@ -38,6 +40,22 @@ export default class Banner extends Component {
 				this.slideInBanner();
 			}
 		);
+
+		this.props.registerResizeBanner( this.onPageResize.bind( this ) );
+	}
+
+	onPageResize() {
+		if ( this.state.displayState !== VISIBLE ) {
+			return;
+		}
+
+		if ( this.state.isFullPageVisible ) {
+			this.props.skinAdjuster.addSpaceInstantly( this.getFullBannerHeight() );
+			this.fullPageBannerReRender();
+		} else {
+			this.bannerSlider.resize();
+			this.props.skinAdjuster.addSpaceInstantly( this.getMiniBannerHeight() );
+		}
 	}
 
 	// eslint-disable-next-line no-unused-vars
@@ -49,10 +67,17 @@ export default class Banner extends Component {
 			this.props.trackingData.bannerClickTrackRatio
 		);
 		window.scrollTo( 0, 0 );
-		const miniBannerHeight = this.miniBannerTransitionRef.current ? this.miniBannerTransitionRef.current.base.offsetHeight : 0;
-		this.transitionToFullpage( miniBannerHeight );
+		this.transitionToFullpage( this.getMiniBannerHeight() );
 		this.setState( { isFullPageVisible: true } );
 	};
+
+	getMiniBannerHeight() {
+		return this.miniBannerTransitionRef.current ? this.miniBannerTransitionRef.current.base.offsetHeight : 0;
+	}
+
+	getFullBannerHeight() {
+		return this.fullBannerTransitionRef.current ? this.fullBannerTransitionRef.current.base.offsetHeight : 0;
+	}
 
 	closeBanner = e => {
 		this.props.trackingData.tracker.trackBannerEvent(
@@ -73,6 +98,7 @@ export default class Banner extends Component {
 	registerFullpageBannerTransition = cb => { this.transitionToFullpage = cb; };
 	registerStartHighlight = cb => { this.startHighlight = cb; };
 	registerAdjustFollowupBannerHeight = cb => { this.adjustFollowupBannerHeight = cb; };
+	registerFullPageBannerReRender = cb => { this.fullPageBannerReRender = cb; };
 	onMiniBannerSlideInFinished = () => {
 		this.bannerSlider.enableAutoplay();
 		this.adjustFollowupBannerHeight( this.miniBannerTransitionRef.current.getHeight() );
@@ -107,10 +133,12 @@ export default class Banner extends Component {
 				<FollowupTransition
 					registerDisplayBanner={ this.registerFullpageBannerTransition }
 					registerFirstBannerFinished={ this.registerAdjustFollowupBannerHeight }
+					registerFullPageBannerReRender={ this.registerFullPageBannerReRender }
 					onFinish={ () => { this.startHighlight(); } }
 					transitionDuration={ 1250 }
 					skinAdjuster={ props.skinAdjuster }
 					hasStaticParent={ false }
+					ref={this.fullBannerTransitionRef}
 				>
 					<FullpageBanner
 						{...props}

--- a/mobile_preact/Banner.jsx
+++ b/mobile_preact/Banner.jsx
@@ -2,6 +2,7 @@
 import { Component, h, createRef } from 'preact';
 import classNames from 'classnames';
 import { Slider } from '../shared/banner_slider';
+import debounce from '../shared/debounce';
 
 import BannerTransition from '../shared/components/BannerTransition';
 import MiniBanner from './components/MiniBanner';
@@ -41,7 +42,7 @@ export default class Banner extends Component {
 			}
 		);
 
-		this.props.registerResizeBanner( this.onPageResize.bind( this ) );
+		this.props.registerResizeBanner( debounce( this.onPageResize.bind( this ), 200 ) );
 	}
 
 	onPageResize() {

--- a/shared/banner_slider.js
+++ b/shared/banner_slider.js
@@ -61,4 +61,8 @@ export class Slider {
 	getCurrentSlide() {
 		return this.slider.selectedIndex + 1;
 	}
+
+	resize() {
+		this.slider.resize();
+	}
 }

--- a/shared/components/FollowupTransition.jsx
+++ b/shared/components/FollowupTransition.jsx
@@ -33,6 +33,9 @@ export default class BannerTransition extends Component {
 		/** A registration callback to signal to this component that the previous banner has rendered  */
 		registerFirstBannerFinished: PropTypes.func,
 
+		/** A registration callback to signal to this component that the page size changed  */
+		registerFullPageBannerReRender: PropTypes.func,
+
 		/** Transition duration in milliseconds */
 		transitionDuration: PropTypes.number,
 
@@ -61,6 +64,9 @@ export default class BannerTransition extends Component {
 		if ( this.props.registerFirstBannerFinished ) {
 			this.props.registerFirstBannerFinished( this.adjustPositionForFirstBanner );
 		}
+		if ( this.props.registerFullPageBannerReRender ) {
+			this.props.registerFullPageBannerReRender( this.reRender );
+		}
 		this.setState( { transitionPhase: READY } );
 	}
 
@@ -76,6 +82,10 @@ export default class BannerTransition extends Component {
 			return;
 		}
 		this.setState( { miniBannerHeight: firstBannerHeight } );
+	};
+
+	reRender = () => {
+		this.forceUpdate();
 	};
 
 	/**

--- a/shared/debounce.js
+++ b/shared/debounce.js
@@ -1,0 +1,11 @@
+export default function debounce( callback, delay ) {
+	let timer = null;
+	return () => {
+		let context = this;
+		let args = arguments;
+		clearTimeout( timer );
+		timer = setTimeout( () => {
+			callback.apply( context, args );
+		}, delay );
+	};
+}

--- a/test/debounce_test.js
+++ b/test/debounce_test.js
@@ -1,0 +1,37 @@
+const assert = require( 'assert' );
+
+import debounce from '../shared/debounce';
+
+describe( 'Debounce', function () {
+
+	it( 'runs the callback when debounce is over', function ( done ) {
+		let finished = false;
+
+		debounce( function () {
+			finished = true;
+		}, 2 )();
+
+		setTimeout( function () {
+			assert.ok( finished );
+			done();
+		}, 5 );
+	} );
+
+	it( 'extends the callback on a new event', function ( done ) {
+		let finished = false;
+
+		let event = debounce( function () {
+			finished = true;
+		}, 3 );
+
+		event();
+		setTimeout( function () {
+			event();
+		}, 2 );
+
+		setTimeout( function () {
+			assert.ok( !finished );
+			done();
+		}, 4 );
+	} );
+} );


### PR DESCRIPTION
On orientation change this does the following:

- When mini banner is displayed, forces the slider to update size before calculating banner size
- When full page banner is displayed, forces it to re-render

https://phabricator.wikimedia.org/T247226