### PR TITLE
Fix fullpage banner location on resize

### DIFF
--- a/mobile_english_preact/Banner.jsx
+++ b/mobile_english_preact/Banner.jsx
@@ -56,6 +56,7 @@ export default class Banner extends Component {
 		} else {
 			this.bannerSlider.resize();
 			this.props.skinAdjuster.addSpaceInstantly( this.getMiniBannerHeight() );
+			this.adjustFollowupBannerHeight( this.miniBannerTransitionRef.current.getHeight() );
 		}
 	}
 

--- a/mobile_preact/Banner.jsx
+++ b/mobile_preact/Banner.jsx
@@ -56,6 +56,7 @@ export default class Banner extends Component {
 		} else {
 			this.bannerSlider.resize();
 			this.props.skinAdjuster.addSpaceInstantly( this.getMiniBannerHeight() );
+			this.adjustFollowupBannerHeight( this.miniBannerTransitionRef.current.getHeight() );
 		}
 	}
 


### PR DESCRIPTION
This tells the fullpage part of the mobile banner to fix it's location after a window resize has happened.

https://phabricator.wikimedia.org/T247226

Related to https://github.com/wmde/fundraising-banners/pull/316