### PR TITLE
Shorten placeholder text for mobile banners

### DIFF
--- a/desktop_preact/Banner.jsx
+++ b/desktop_preact/Banner.jsx
@@ -123,6 +123,7 @@ export default class Banner extends Component {
 								formatters={props.formatters}
 								impressionCounts={props.impressionCounts}
 								onFormInteraction={this.onFormInteraction}
+								customAmountPlaceholder={ props.translations[ 'custom-amount-placeholder' ] }
 							/>
 						</div>
 						<div className="close">

--- a/english_preact/Banner.jsx
+++ b/english_preact/Banner.jsx
@@ -146,6 +146,7 @@ export default class Banner extends Component {
 								formatters={props.formatters}
 								impressionCounts={props.impressionCounts}
 								onFormInteraction={this.onFormInteraction}
+								customAmountPlaceholder={ props.translations[ 'custom-amount-placeholder' ] }
 							/>
 						</div>
 						<div className="close">

--- a/mobile_english_preact/components/FullpageBanner.jsx
+++ b/mobile_english_preact/components/FullpageBanner.jsx
@@ -2,7 +2,7 @@
 import { h, Component } from 'preact';
 import classNames from 'classnames';
 
-import DonationFormWithHeaders from '../../shared/components/ui/form/DonationForm';
+import DonationForm from '../../shared/components/ui/form/DonationForm';
 import ProgressBar from '../../shared/components/ui/ProgressBar';
 import Infobox from '../../shared/components/ui/Infobox';
 
@@ -38,14 +38,15 @@ export default class FullpageBanner extends Component {
 					/>
 				</div>
 			</div>
-			<DonationFormWithHeaders
+			<DonationForm
 				formItems={props.formItems}
 				bannerName={props.bannerName}
 				campaignName={props.campaignName}
 				formatters={props.formatters}
 				impressionCounts={props.impressionCounts}
+				customAmountPlaceholder={ props.translations[ 'custom-amount-placeholder-short' ] }
 			/>
-			<div className="smallprint">
+			<div className="smallprint language-info">
 				Please note that the next steps of the donation process are in German.
 			</div>
 			<div className="smallprint">

--- a/mobile_english_preact/styles/DonationForm.pcss
+++ b/mobile_english_preact/styles/DonationForm.pcss
@@ -1,6 +1,6 @@
 .wmde-banner {
 	.form {
-		padding: 0 40px 20px;
+		padding: 0 40px 2px;
 		position: relative;
 		height: 100%;
 	}

--- a/mobile_english_preact/styles/FullpageBanner.pcss
+++ b/mobile_english_preact/styles/FullpageBanner.pcss
@@ -126,4 +126,8 @@
 			}
 		}
 	}
+
+	.language-info {
+		padding-bottom: 15px;
+	}
 }

--- a/mobile_preact/components/FullpageBanner.jsx
+++ b/mobile_preact/components/FullpageBanner.jsx
@@ -42,6 +42,7 @@ export default class FullpageBanner extends Component {
 				campaignName={props.campaignName}
 				formatters={props.formatters}
 				impressionCounts={props.impressionCounts}
+				customAmountPlaceholder={ props.translations[ 'custom-amount-placeholder-short' ] }
 			/>
 			<div className="smallprint">
 				<span>

--- a/mobile_preact/components/ui/form/DonationFormWithHeaders.jsx
+++ b/mobile_preact/components/ui/form/DonationFormWithHeaders.jsx
@@ -96,7 +96,7 @@ export default function DonationFormWithHeaders( props ) {
 							value={ customAmount }
 							onInput={ e => updateCustomAmount( e.target.value ) }
 							onBlur={ e => validateCustomAmount( e.target.value ) }
-							placeholder={ Translations[ 'custom-amount-placeholder' ] }
+							placeholder={ props.customAmountPlaceholder }
 							language={
 								/* eslint-disable-next-line dot-notation */
 								Translations[ 'LANGUAGE' ]

--- a/pad_english_preact/Banner.jsx
+++ b/pad_english_preact/Banner.jsx
@@ -146,6 +146,7 @@ export default class Banner extends Component {
 								formatters={props.formatters}
 								impressionCounts={props.impressionCounts}
 								onFormInteraction={this.onFormInteraction}
+								customAmountPlaceholder={ props.translations[ 'custom-amount-placeholder' ] }
 							/>
 						</div>
 						<div className="close">

--- a/pad_preact/Banner.jsx
+++ b/pad_preact/Banner.jsx
@@ -137,6 +137,7 @@ export default class Banner extends Component {
 								formatters={props.formatters}
 								impressionCounts={props.impressionCounts}
 								onFormInteraction={this.onFormInteraction}
+								customAmountPlaceholder={ props.translations[ 'custom-amount-placeholder' ] }
 							/>
 						</div>
 						<div className="close">

--- a/shared/components/ui/form/DonationForm.jsx
+++ b/shared/components/ui/form/DonationForm.jsx
@@ -68,7 +68,7 @@ export default function DonationForm( props ) {
 						value={ customAmount }
 						onInput={ e => updateCustomAmount( e.target.value ) }
 						onBlur={ e => validateCustomAmount( e.target.value ) }
-						placeholder={ Translations[ 'custom-amount-placeholder' ] }
+						placeholder={ props.customAmountPlaceholder }
 						language={
 							/* eslint-disable-next-line dot-notation */
 							Translations[ 'LANGUAGE' ]

--- a/shared/messages/de.js
+++ b/shared/messages/de.js
@@ -12,6 +12,7 @@ const Translations = {
 	'sms-info-message': 'SMS mit "WIKI" an die 81190. Kosten zzgl. einer Standard-SMS.',
 	'sms-payment-message': '5 € per SMS',
 	'custom-amount-placeholder': 'Wunschbetrag',
+	'custom-amount-placeholder-short': 'anderer',
 	'submit-label': 'Weiter, um Spende abzuschließen',
 	'use-of-funds-link': 'Wohin geht meine Spende?',
 	'prefix-days-left': 'Nur noch',

--- a/shared/messages/en.js
+++ b/shared/messages/en.js
@@ -11,6 +11,7 @@ const Translations = {
 	'sms-info-message': 'Text "WIKI" to 81190. Additional costs for sending text messages may apply.',
 	'sms-payment-message': '5 € by text message',
 	'custom-amount-placeholder': 'Other amount',
+	'custom-amount-placeholder-short': 'other',
 	'submit-label': 'Proceed with the donation',
 	'use-of-funds-link': 'Where does my donation go?',
 	'prefix-days-left': 'Only',

--- a/wikipedia.de/Banner.jsx
+++ b/wikipedia.de/Banner.jsx
@@ -113,6 +113,7 @@ export default class Banner extends Component {
 							formatters={ props.formatters }
 							impressionCounts={ props.impressionCounts }
 							onFormInteraction={ this.onFormInteraction }
+							customAmountPlaceholder={ props.translations[ 'custom-amount-placeholder' ] }
 						/>
 					</div>
 					<div className="close">


### PR DESCRIPTION
Make the placeholder text for the custom amount field
insertable via a property in each banner.
The mobile banners get shorter placeholder texts now.

Move the language info closer to the submit button.

https://phabricator.wikimedia.org/T247594