### PR TITLE
Put banner transition name in CSS class

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
 	"env": {
 		"browser": true,
 		"node": true,
+		"es6": true,
 		"jquery": true,
 		"qunit": true,
 		"mocha": true

--- a/shared/components/BannerTransition.jsx
+++ b/shared/components/BannerTransition.jsx
@@ -10,6 +10,13 @@ const READY = 1;
 const SLIDING = 2;
 const FINISHED = 3;
 
+const STATE_NAMES = new Map( [
+	[ PAGELOADING, 'loading' ],
+	[ READY, 'ready' ],
+	[ SLIDING, 'sliding' ],
+	[ FINISHED, 'finished' ]
+] );
+
 export default class BannerTransition extends Component {
 	ref = createRef();
 
@@ -74,10 +81,13 @@ export default class BannerTransition extends Component {
 				bannerStyle = { top: 0 };
 		}
 		return <div style={ bannerStyle } ref={this.ref}
-			className={ classNames( {
-				'banner-position': true,
-				'banner-position--fixed': props.fixed
-			} )}
+			className={ classNames(
+				`banner-position--state-${STATE_NAMES.get( state.transitionPhase ) }`,
+				{
+					'banner-position': true,
+					'banner-position--fixed': props.fixed
+				}
+			)}
 			onTransitionEnd={ this.onTransitionEnd}>
 			{ props.children }
 		</div>;


### PR DESCRIPTION
This will enable our banner automation framework to determine if the
banner is shown or not: When an element with the class
`banner-position--state-finished` exists, then the banner should
display.