### PR TITLE
Add bank info to fullpage mobile banners

### DIFF
--- a/mobile_english_preact/components/FullpageBanner.jsx
+++ b/mobile_english_preact/components/FullpageBanner.jsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import DonationForm from '../../shared/components/ui/form/DonationForm';
 import ProgressBar from '../../shared/components/ui/ProgressBar';
 import Infobox from '../../shared/components/ui/Infobox';
+import Footer from '../../shared/components/ui/Footer';
 
 export default class FullpageBanner extends Component {
 	render( props ) {
@@ -49,6 +50,9 @@ export default class FullpageBanner extends Component {
 			<div className="smallprint language-info">
 				Please note that the next steps of the donation process are in German.
 			</div>
+
+			<Footer/>
+
 			<div className="smallprint">
 				<span>
 					<a href={`https://spenden.wikimedia.de/spenden/Impressum?${ trackingParams }`} target="_blank">Legal Details</a>

--- a/mobile_english_preact/styles/Footer.pcss
+++ b/mobile_english_preact/styles/Footer.pcss
@@ -1,0 +1,32 @@
+.wmde-banner {
+	.footer {
+		font-size: 16px;
+		line-height: 22px;
+		padding-bottom: 15px;
+
+		&__info {
+			text-transform: uppercase;
+		}
+
+		&__importantinfo {
+			font-weight: bolder;
+		}
+
+		&__item {
+			white-space: nowrap;
+
+			&--rightflex {
+				flex-grow: 1;
+				text-align: right;
+			}
+
+			span {
+				margin-right: 0.3em;
+			}
+		}
+	}
+
+	.application-of-funds-link {
+		display: none;
+	}
+}

--- a/mobile_english_preact/styles/styles_ctrl.pcss
+++ b/mobile_english_preact/styles/styles_ctrl.pcss
@@ -13,3 +13,4 @@
 @import './BannerText.pcss';
 @import './TextHighlight.pcss';
 @import './ProgressBar.pcss';
+@import './Footer.pcss';

--- a/mobile_preact/components/ui/form/DonationFormWithHeaders.jsx
+++ b/mobile_preact/components/ui/form/DonationFormWithHeaders.jsx
@@ -14,6 +14,7 @@ import usePaymentMethod from '../../../../shared/components/ui/form/hooks/use_pa
 import { amountMessage, validateRequired } from '../../../../shared/components/ui/form/utils';
 import { Intervals, PaymentMethods } from '../../../../shared/components/ui/form/FormItemsBuilder';
 import SubmitValues from '../../../../shared/components/ui/form/SubmitValues';
+import Footer from '../../../../shared/components/ui/Footer';
 
 export default function DonationFormWithHeaders( props ) {
 	const Translations = useContext( TranslationContext );
@@ -128,6 +129,8 @@ export default function DonationFormWithHeaders( props ) {
 					<span className="button-group__label">{ Translations[ 'submit-label' ] }</span>
 				</button>
 			</div>
+
+			<Footer/>
 
 			<SubmitValues
 				amount={ props.formatters.amountForServerFormatter( numericAmount ) }

--- a/mobile_preact/styles/Footer.pcss
+++ b/mobile_preact/styles/Footer.pcss
@@ -1,0 +1,32 @@
+.wmde-banner {
+	.footer {
+		font-size: 16px;
+		line-height: 22px;
+		margin-top: 1em;
+
+		&__info {
+			text-transform: uppercase;
+		}
+
+		&__importantinfo {
+			font-weight: bolder;
+		}
+
+		&__item {
+			white-space: nowrap;
+
+			&--rightflex {
+				flex-grow: 1;
+				text-align: right;
+			}
+
+			span {
+				margin-right: 0.3em;
+			}
+		}
+	}
+
+	.application-of-funds-link {
+		display: none;
+	}
+}

--- a/mobile_preact/styles/styles_ctrl.pcss
+++ b/mobile_preact/styles/styles_ctrl.pcss
@@ -13,3 +13,4 @@
 @import './BannerText.pcss';
 @import './TextHighlight.pcss';
 @import './ProgressBar.pcss';
+@import './Footer.pcss';


### PR DESCRIPTION
Reuse the footer component and hide unnecessary info with css.
https://phabricator.wikimedia.org/T255970