### PR TITLE
Adapt test campaign parameters

### DIFF
--- a/desktop_preact/Banner.jsx
+++ b/desktop_preact/Banner.jsx
@@ -142,7 +142,7 @@ export default class Banner extends Component {
 							<ProgressBar
 								formatters={props.formatters}
 								daysLeft={campaignProjection.getRemainingDays()}
-								donationAmount={campaignProjection.getProjectedDonationSum() * 0.6}
+								donationAmount={campaignProjection.getProjectedDonationSum()}
 								goalDonationSum={campaignProjection.goalDonationSum}
 								missingAmount={campaignProjection.getProjectedRemainingDonationSum()}
 								setStartAnimation={this.registerStartProgressbar}/>

--- a/shared/global_banner_settings.js
+++ b/shared/global_banner_settings.js
@@ -1,13 +1,13 @@
 // TODO When all banners use `createCampaignParameters`, rename the properties and use this object directly.
 module.exports = {
-	'goalDonationSum': 8200000,
-	'donations-date-base': '2019-10-23',
-	'donations-collected-base': 124434,
+	'goalDonationSum': 9000000,
+	'donations-date-base': '2020-07-09',
+	'donations-collected-base': 6124434,
 	'donators-base': 35814,
 	'appr-donations-per-minute': 104,
 	'appr-donators-per-minute': 4.805,
 	'impressions-per-day-in-million': 6,
-	'campaign-start-date': '2019-10-23',
-	'campaign-end-date': '2019-12-31',
+	'campaign-start-date': '2020-07-01',
+	'campaign-end-date': '2020-09-31',
 	'banner-close-track-ratio': 1
 };


### PR DESCRIPTION
Simulate a campaign starting in July to have a pretty progress bar with
non-negative days left.