### PR TITLE
Update debounce tests

### DIFF
--- a/test/debounce_test.js
+++ b/test/debounce_test.js
@@ -1,8 +1,18 @@
 const assert = require( 'assert' );
-
+import sinon from 'sinon';
 import debounce from '../shared/debounce';
 
 describe( 'Debounce', function () {
+
+	let clock;
+
+	beforeEach( function () {
+		clock = sinon.useFakeTimers();
+	} );
+
+	afterEach( function () {
+		clock.restore();
+	} );
 
 	it( 'runs the callback when debounce is over', function ( done ) {
 		let finished = false;
@@ -14,7 +24,9 @@ describe( 'Debounce', function () {
 		setTimeout( function () {
 			assert.ok( finished );
 			done();
-		}, 5 );
+		}, 3 );
+
+		clock.tick( 4 );
 	} );
 
 	it( 'extends the callback on a new event', function ( done ) {
@@ -33,5 +45,7 @@ describe( 'Debounce', function () {
 			assert.ok( !finished );
 			done();
 		}, 4 );
+
+		clock.tick( 5 );
 	} );
 } );


### PR DESCRIPTION
This change is to use Sinon as a timer replacement to stop random test failures caused by setTimeout (https://travis-ci.org/github/wmde/fundraising-banners/builds/731559114)