### PR TITLE
Improve custom amount handling

### DIFF
--- a/desktop/components/ui/form/DonationFormWidthInfoHeader.jsx
+++ b/desktop/components/ui/form/DonationFormWidthInfoHeader.jsx
@@ -77,6 +77,7 @@ export default function DonationForm( props ) {
 					<SelectCustomAmount
 						fieldname="select-amount"
 						value={ customAmount }
+						selectedAmount={ selectedAmount }
 						onInput={ e => updateCustomAmount( e.target.value ) }
 						onBlur={ e => validateCustomAmount( e.target.value ) }
 						placeholder={ props.customAmountPlaceholder }

--- a/mobile/components/ui/form/DonationFormWithHeaders.jsx
+++ b/mobile/components/ui/form/DonationFormWithHeaders.jsx
@@ -96,6 +96,7 @@ export default function DonationFormWithHeaders( props ) {
 						<SelectCustomAmount
 							fieldname="select-amount"
 							value={ customAmount }
+							selectedAmount={ selectedAmount }
 							onInput={ e => updateCustomAmount( e.target.value ) }
 							onBlur={ e => validateCustomAmount( e.target.value ) }
 							placeholder={ props.customAmountPlaceholder }

--- a/mobile/components/ui/form/DonationFormWithHeaders_var.jsx
+++ b/mobile/components/ui/form/DonationFormWithHeaders_var.jsx
@@ -172,6 +172,7 @@ export default function DonationFormWithHeaders( props ) {
 						<SelectCustomAmount
 							fieldname="select-amount"
 							value={ customAmount }
+							selectedAmount={ selectedAmount }
 							onInput={ e => updateCustomAmount( e.target.value ) }
 							onBlur={ e => validateCustomAmount( e.target.value ) }
 							placeholder={ props.customAmountPlaceholder }

--- a/pad/components/ui/form/DonationForm.jsx
+++ b/pad/components/ui/form/DonationForm.jsx
@@ -93,6 +93,7 @@ export default function DonationForm( props ) {
 				>
 					<SelectCustomAmount
 						value={ customAmount }
+						selectedAmount={ selectedAmount }
 						onInput={ e => updateCustomAmount( e.target.value ) }
 						onBlur={ e => validateCustomAmount( e.target.value ) }
 						placeholder={ Translations[ 'custom-amount-placeholder' ] }

--- a/shared/components/ui/form/DonationForm.jsx
+++ b/shared/components/ui/form/DonationForm.jsx
@@ -69,6 +69,7 @@ export default function DonationForm( props ) {
 					<SelectCustomAmount
 						fieldname="select-amount"
 						value={ customAmount }
+						selectedAmount={ selectedAmount }
 						onInput={ e => updateCustomAmount( e.target.value ) }
 						onBlur={ e => validateCustomAmount( e.target.value ) }
 						placeholder={ props.customAmountPlaceholder }

--- a/shared/components/ui/form/SelectCustomAmount.jsx
+++ b/shared/components/ui/form/SelectCustomAmount.jsx
@@ -9,13 +9,12 @@ export default class SelectCustomAmount extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			focused: false,
-			showEuro: false
+			focused: false
 		};
 	}
 
 	onFocus = ( e ) => {
-		this.setState( { showEuro: true, focused: true } );
+		this.setState( { focused: true } );
 		if ( this.props.value !== '' ) {
 			e.target.select();
 		}
@@ -25,25 +24,23 @@ export default class SelectCustomAmount extends Component {
 		if ( this.ref.current ) {
 			this.ref.current.focus();
 		}
-	};
+	}
 
 	onBlur = ( e ) => {
 		this.setState( { focused: false } );
 		this.props.onBlur( e );
-		if ( this.props.value === '' || this.props.value === null ) {
-			this.setState( { showEuro: false } );
-		}
 	};
 
 	render( props, state ) {
+		const anyAmountWasSelected = props.selectedAmount === null && props.value !== null;
+		const showEuro = ( props.value !== null && props.value !== '' ) || state.focused;
 		return <label className="select-group__option select-group__option--amount-other-input">
 			<input type="radio"
 				name={ props.fieldname }
 				className="select-group__input"
 				value=""
-				checked={ state.focused || props.value !== null }
+				checked={ state.focused || anyAmountWasSelected }
 				onClick={ this.onRadioClicked }
-				onChange={ this.onBlur }
 			/>
 
 			<div className={ classNames(
@@ -54,7 +51,7 @@ export default class SelectCustomAmount extends Component {
 				} ) }
 			>
 
-				{ state.showEuro ? <span className="select-group__custom-input--euro-symbol">&euro;</span> : null }
+				{ showEuro ? <span className="select-group__custom-input--euro-symbol">&euro;</span> : null }
 
 				<input type="text"
 					value={ props.value || '' }

--- a/shared/components/ui/form/hooks/use_amount.js
+++ b/shared/components/ui/form/hooks/use_amount.js
@@ -33,11 +33,15 @@ function amountReducer( state, action ) {
 				customAmount: action.payload,
 				numericAmount: parseAmount( action.payload )
 			};
-		case 'FINISH_CUSTOM_AMOUNT':
+		case 'CUSTOM_AMOUNT_LOST_FOCUS':
+			// Don't validate immediately when field is empty
 			if ( action.payload === '' ) {
 				return {
 					...state,
-					customAmount: ''
+					selectedAmount: null,
+					customAmount: action.payload,
+					numericAmount: 0,
+					amountValidity: UNSET
 				};
 			}
 			numericAmount = parseAmount( action.payload );
@@ -80,7 +84,7 @@ export default function useAmountWithCustom( initial, customAmountFormatter ) {
 		{
 			selectAmount: createAction( 'AMOUNT_SELECTED', dispatch ),
 			updateCustomAmount: createAction( 'AMOUNT_TYPED', dispatch ),
-			validateCustomAmount: amount => dispatch( { type: 'FINISH_CUSTOM_AMOUNT', payload: amount, formatter: customAmountFormatter } ),
+			validateCustomAmount: amount => dispatch( { type: 'CUSTOM_AMOUNT_LOST_FOCUS', payload: amount, formatter: customAmountFormatter } ),
 			setAmountValidity: createAction( 'SET_VALIDITY', dispatch )
 		}
 


### PR DESCRIPTION
This change prevents an error message from popping up when the user
focuses the custom amount field and then selects a different amount or
leaves the field via tab. The "Custom Amount" *option* (visible as a
radio button in some banners) stays selected, but the internal state
will still be "unset".

This change also improves the display of the Euro sign in the
SelectCustomAmount component: it only displays the Euro sign when the
amount field has focus or when it has a non-empty value.
