### PR TITLE
Adjust custom amount for placeholder visibility on English desktop banners

### DIFF
--- a/english/styles/SelectGroup.pcss
+++ b/english/styles/SelectGroup.pcss
@@ -154,6 +154,7 @@ $select-group-line-height: 30px;
 			border: 1px solid $color-gray-light;
 			box-sizing: border-box;
 			width: 100%;
+			min-width: 110px;
 			margin: 2px 0;
 			line-height: 25px;
 			height: 26px;
@@ -241,6 +242,13 @@ $select-group-line-height: 30px;
 			@media ( min-width: $breakpoint_l ) {
 				width: 50%;
 			}
+		}
+	}
+
+	.select-group__option--select-interval-6 {
+		display: none;
+		@media ( min-width: $breakpoint_l ) {
+			display: flex;
 		}
 	}
 }

--- a/english/styles/variables_ctrl.pcss
+++ b/english/styles/variables_ctrl.pcss
@@ -28,5 +28,5 @@ Always work 'mobile first':
 $breakpoint_xs: 900px;
 $breakpoint_s: 1024px;
 $breakpoint_m: 1090px;
-$breakpoint_l: 1400px;
+$breakpoint_l: 1300px;
 $breakpoint_xl: 1580px;

--- a/shared/components/ui/form/SelectGroup.jsx
+++ b/shared/components/ui/form/SelectGroup.jsx
@@ -30,7 +30,10 @@ export function SelectGroup( props ) {
 
 		<div className="select-group">
 			{ props.selectionItems.map( ( { value, label } ) => (
-				<label className={ 'select-group__option' } key={ value }>
+				<label className={ classNames(
+					'select-group__option',
+					`select-group__option--${ props.fieldname }-${value.replace( ' ', '-' )}`,
+				) } key={ value }>
 					<input
 						type="radio"
 						onClick={ props.onSelected }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T266887

This adjusts the minimium width of the custom amount field on smaller screens to make sure the placeholder stays visible.