### PR TITLE
Adjust custom amount for placeholder visibility on DE desktop banners

### DIFF
--- a/desktop/styles/SelectGroup.pcss
+++ b/desktop/styles/SelectGroup.pcss
@@ -154,6 +154,7 @@ $select-group-line-height: 30px;
 			border: 1px solid $color-gray-light;
 			box-sizing: border-box;
 			width: 100%;
+			min-width: 110px;
 			margin: 2px 0;
 			line-height: 25px;
 			height: 26px;
@@ -240,6 +241,13 @@ $select-group-line-height: 30px;
 			@media ( min-width: $breakpoint_l ) {
 				width: 50%;
 			}
+		}
+	}
+
+	.select-group__option--select-interval-6 {
+		display: none;
+		@media ( min-width: $breakpoint_l ) {
+			display: flex;
 		}
 	}
 }

--- a/desktop/styles/SelectGroup_var.pcss
+++ b/desktop/styles/SelectGroup_var.pcss
@@ -165,6 +165,7 @@ $select-group-line-height: 30px;
 			border: 1px solid $color-gray-light;
 			box-sizing: border-box;
 			width: 100%;
+			min-width: 110px;
 			margin: 2px 0;
 			line-height: 25px;
 			height: 26px;
@@ -251,6 +252,13 @@ $select-group-line-height: 30px;
 			@media ( min-width: $breakpoint_l ) {
 				width: 50%;
 			}
+		}
+	}
+
+	.select-group__option--select-interval-6 {
+		display: none;
+		@media ( min-width: $breakpoint_l ) {
+			display: flex;
 		}
 	}
 }

--- a/shared/components/ui/form/SelectGroup.jsx
+++ b/shared/components/ui/form/SelectGroup.jsx
@@ -32,6 +32,7 @@ export function SelectGroup( props ) {
 			{ props.selectionItems.map( ( { value, label } ) => (
 				<label key={ value } className={ classNames(
 					'select-group__option',
+					`select-group__option--${ props.fieldname }-${value.replace( ' ', '-' )}`,
 					{ 'select-group__disabled': props.disabledOptions.indexOf( value ) > -1 }
 				) }>
 					<input


### PR DESCRIPTION
https://phabricator.wikimedia.org/T266887

This adjusts the minimium width of the custom amount field on smaller screens to make sure the placeholder stays visible.
