### PR TITLE
Fix mobile EN 01 slides

### DIFF
--- a/mobile_english/components/Slides.jsx
+++ b/mobile_english/components/Slides.jsx
@@ -1,20 +1,21 @@
 // eslint-disable-next-line no-unused-vars
 import { h } from 'preact';
 
-export default function Slides( { formattedGoalDonationSumNumeric, currentDayName, numberOfDonors, campaignParameters, progressBar } ) {
+export default function Slides( { formattedGoalDonationSumNumeric, currentDayName, visitorsVsDonorsSentence, progressBar } ) {
 	return <div className="mini-banner-carousel">
-		<div className="carousel-cell">
-			<p>To all our readers in Germany. We will get straight to the point:
-				This { currentDayName } we ask you to protect Wikipedia's independence.</p>
-		</div>
-		<div className="carousel-cell">
-			<p>Our fundraising appeal is displayed over { campaignParameters.millionImpressionsPerDay } million times a day,
-				but currently only { numberOfDonors } people have donated. The price of a coffee is all we need.</p>
-		</div>
 		<div className="carousel-cell">
 			<p className="goal-headline">Our donation target: { formattedGoalDonationSumNumeric } million Euros</p>
 			{ progressBar }
 		</div>
+		<div className="carousel-cell">
+			<p>To all our readers in Germany. We will get straight to the point:
+				This { currentDayName } we ask you to protect Wikipedia's independence.</p>
+		</div>
+		{ visitorsVsDonorsSentence.length > 0 &&
+			<div className="carousel-cell">
+				<p>{ visitorsVsDonorsSentence }</p>
+			</div>
+		}
 		<div className="carousel-cell">
 			<p>If everyone reading this gave a small amount, we could keep Wikipedia thriving for years to come.</p>
 		</div>

--- a/shared/visitors_vs_donors_sentence.js
+++ b/shared/visitors_vs_donors_sentence.js
@@ -16,7 +16,7 @@ export default class VisitorsVsDonorsSentence {
 	}
 
 	getSentence() {
-		if ( this.daysSinceCampaignStart >= 2 ) {
+		if ( this.daysSinceCampaignStart >= 1 ) {
 			return this.text
 				.replace( '{{millionImpressionsPerDay}}', this.millionImpressionsPerDay )
 				.replace( '{{totalNumberOfDonors}}', String( Math.floor( this.projectedNumberOfDonors ) ) );


### PR DESCRIPTION
changes are done according to this comment:
>
- The slide containing the progress bar should be the first.
- The visitors-vs-donors sentence is part of one slide. That's fine, but we should use the placeholder, so it is not displayed on the first campaign day.

https://phabricator.wikimedia.org/T266756#6599732