### PR TITLE
Remove outdated styles from wpde desktop

### DIFF
--- a/wikipedia.de/desktop/styles/styles_ctrl.pcss
+++ b/wikipedia.de/desktop/styles/styles_ctrl.pcss
@@ -10,20 +10,3 @@
 @import '../../../shared/components/ui/use_of_funds/CompanyBudgets.pcss';
 @import '../../../shared/components/ui/use_of_funds/FundsModal.pcss';
 @import '../../../shared/components/ui/use_of_funds/FundsDistributionInfo.pcss';
-
-/*
-@import '../../shared/components/BannerTransition.pcss';
-
-@import 'mobile/MobileBanner.pcss';
-@import 'mobile/MiniBanner.pcss';
-@import 'mobile/Slides.pcss';
-
-@import 'mobile_fullpage/Banner.pcss';
-@import 'mobile_fullpage/FullpageBanner.pcss';
-@import 'mobile_fullpage/BannerText.pcss';
-@import 'mobile_fullpage/DonationForm_var.pcss';
-@import 'mobile_fullpage/Infobox.pcss';
-@import 'mobile_fullpage/ProgressBar.pcss';
-@import 'mobile_fullpage/SelectGroup.pcss';
-@import './TextHighlight.pcss';
-*/

--- a/wikipedia.de/desktop/styles/styles_var.pcss
+++ b/wikipedia.de/desktop/styles/styles_var.pcss
@@ -10,20 +10,3 @@
 @import '../../../shared/components/ui/use_of_funds/CompanyBudgets.pcss';
 @import '../../../shared/components/ui/use_of_funds/FundsModal.pcss';
 @import '../../../shared/components/ui/use_of_funds/FundsDistributionInfo.pcss';
-
-/*
-@import '../../shared/components/BannerTransition.pcss';
-
-@import 'mobile/MobileBanner.pcss';
-@import 'mobile/MiniBanner.pcss';
-@import 'mobile/Slides.pcss';
-
-@import 'mobile_fullpage/Banner.pcss';
-@import 'mobile_fullpage/FullpageBanner.pcss';
-@import 'mobile_fullpage/BannerText.pcss';
-@import 'mobile_fullpage/DonationForm_var.pcss';
-@import 'mobile_fullpage/Infobox.pcss';
-@import 'mobile_fullpage/ProgressBar.pcss';
-@import 'mobile_fullpage/SelectGroup.pcss';
-@import './TextHighlight.pcss';
-*/


### PR DESCRIPTION
wikipedia.de now has its own mobile banner and dnoesn't need to include mbile styles (they were commented out anyway).
