### PR TITLE
Add impression tracking for wp.de

### DIFF
--- a/shared/banner_presenter.js
+++ b/shared/banner_presenter.js
@@ -105,6 +105,7 @@ export default class BannerPresenter {
 			() => {
 				this.impressionCounts.incrementImpressionCounts();
 				displayBanner();
+				this.trackingData.tracker.recordBannerImpression();
 			},
 			this.appearanceDelay
 		);

--- a/shared/event_logging_tracker.js
+++ b/shared/event_logging_tracker.js
@@ -57,4 +57,10 @@ export class EventLoggingTracker {
 			} );
 		}
 	}
+
+	recordBannerImpression() {
+		// Do nothing, on wp.org we're using trackViewPortDimensions
+		// TODO move call to trackViewPortDimensions from bannerPresenter (lines 87-91) to here & test if it has the same effect.
+		//      This will unify tracking more on wp.de and wp.org
+	}
 }


### PR DESCRIPTION
This is a quick fix for tracking impressions on wikipedia.de.

Future refactoring should unify the tracking into one interface,
`recordBannerImpression`.
