### PR TITLE
Remove underline from English custom amount

### DIFF
--- a/english/styles/SelectGroup.pcss
+++ b/english/styles/SelectGroup.pcss
@@ -175,7 +175,6 @@ $select-group-line-height: 30px;
 				font-weight: bold;
 				border: 0 none;
 				box-sizing: border-box;
-				text-decoration: underline;
 				text-align: left;
 
 				@media ( min-width: $breakpoint_l ) {


### PR DESCRIPTION
Removes the underline from the custom amount field on the english desktop banners. This makes them more consistent with the de ones.