### PR TITLE
Fix banner displaying after closing WPDE

### DIFF
--- a/wikipedia.de/desktop/Banner.jsx
+++ b/wikipedia.de/desktop/Banner.jsx
@@ -44,14 +44,13 @@ export default class Banner extends Component {
 
 	componentDidMount() {
 		this.props.registerDisplayBanner(
-			() => {
-				this.setState( { displayState: VISIBLE } );
-			}
+			() => {}
 		);
 		this.props.registerResizeBanner( this.adjustSurroundingSpace.bind( this ) );
 		this.adjustSurroundingSpace();
 		this.startProgressbar();
 		this.props.onFinishedTransitioning();
+		this.setState( { displayState: VISIBLE } );
 	}
 
 	adjustSurroundingSpace() {


### PR DESCRIPTION
After closing the banner,
the banner showed up after the presenting animation time.

https://phabricator.wikimedia.org/T267899