### PR TITLE
Set close cookie for WPDE mobile banner

### DIFF
--- a/wikipedia.de/mobile/Banner.jsx
+++ b/wikipedia.de/mobile/Banner.jsx
@@ -129,6 +129,7 @@ export default class Banner extends Component {
 		e.preventDefault();
 		this.setState( {
 			displayState: CLOSED,
+			setCookie: true,
 			isFullPageVisible: false
 		} );
 		this.props.onClose(


### PR DESCRIPTION
Sets the cookie to not show the banner again after closing it once.