### PR TITLE
Do not show banner if media-viewer got opened

### DIFF
--- a/shared/banner_presenter.js
+++ b/shared/banner_presenter.js
@@ -1,6 +1,10 @@
 import SizeIssueIndicator from './track_size_issues';
 import { getSkinAdjuster } from './skin';
-import { mediaWikiIsShowingContentPage, onMediaWiki } from './mediawiki_checks';
+import {
+	mediaWikiIsShowingContentPage,
+	mediaWikiMainContentIsHiddenByLightbox,
+	onMediaWiki
+} from './mediawiki_checks';
 import { createElement, render } from 'preact';
 import InterruptibleTimeout from './interruptible_timeout';
 import { VIEWPORT_TRACKING_IDENTIFIER, VIEWPORT_TRACKING_SUBMITTED_EVENT_IDENTIFIER } from './event_logging_tracker';
@@ -32,7 +36,7 @@ export default class BannerPresenter {
 		}
 		const sizeIssueIndicator = new SizeIssueIndicator( sizeIssueThreshold );
 
-		if ( onMediaWiki() && !mediaWikiIsShowingContentPage() ) {
+		if ( !mediaWikiIsShowingContentPage() || mediaWikiMainContentIsHiddenByLightbox() ) {
 			mw.centralNotice.setBannerLoadedButHidden();
 			return;
 		}
@@ -103,6 +107,10 @@ export default class BannerPresenter {
 		const bannerDisplayTimeout = new InterruptibleTimeout();
 		bannerDisplayTimeout.run(
 			() => {
+				if ( mediaWikiMainContentIsHiddenByLightbox() ) {
+					mw.centralNotice.setBannerLoadedButHidden();
+					return;
+				}
 				this.impressionCounts.incrementImpressionCounts();
 				displayBanner();
 				this.trackingData.tracker.recordBannerImpression();

--- a/shared/mediawiki_checks.js
+++ b/shared/mediawiki_checks.js
@@ -5,3 +5,8 @@ export function onMediaWiki() {
 export function mediaWikiIsShowingContentPage() {
 	return onMediaWiki() && window.mw.config.get( 'wgAction' ) === 'view';
 }
+
+export function mediaWikiMainContentIsHiddenByLightbox() {
+	const lightBoxElement = document.getElementsByClassName( ' mw-mmv-lightbox-open' );
+	return ( lightBoxElement.length > 0 );
+}

--- a/shared/skin/minerva.js
+++ b/shared/skin/minerva.js
@@ -1,6 +1,8 @@
 import Skin from './Skin';
 import $ from 'jquery';
 
+// usually mobile skin
+
 export default class Minerva extends Skin {
 	constructor() {
 		super();

--- a/shared/skin/vector.js
+++ b/shared/skin/vector.js
@@ -1,6 +1,8 @@
 import Skin from './Skin';
 import $ from 'jquery';
 
+// usually desktop skin
+
 export default class Vector extends Skin {
 	constructor() {
 		super();


### PR DESCRIPTION
If an image is clicked and the mediaviewer is open, the main content of the page
gets set invisible. This change checks if the main content is visible
and the banner can be rendered there properly.

https://phabricator.wikimedia.org/T268918