### PR TITLE
Update node.js to 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,10 @@ version: '2'
 
 services:
   js-build:
-    image: node:14
+    image: node:16
     volumes:
       - ./:/code
-      - ~/.npm:/npm-cache
     working_dir: /code
-    environment:
-      - npm_config_cache=/npm-cache
   js-serve:
     extends: js-build
     ports:


### PR DESCRIPTION
This avoids errors when installing with npm 6 (our package-lock.json is
already for version 7).

Removed caching npm metadata on host machine when using Docker. This was
introduced for local development, but can have unforeseen side effects
and errors when using different node/npm versions or platforms.
