### PR TITLE
Generate form query and action in a hook

### DIFF
--- a/mobile/components/ui/form/DonationFormWithHeaders.jsx
+++ b/mobile/components/ui/form/DonationFormWithHeaders.jsx
@@ -15,6 +15,7 @@ import { amountMessage, validateRequired } from '../../../../shared/components/u
 import { Intervals, PaymentMethods } from '../../../../shared/components/ui/form/FormItemsBuilder';
 import SubmitValues from '../../../../shared/components/ui/form/SubmitValues';
 import Footer from '../../../../shared/components/ui/EasySelectFooter';
+import useFormAction from '../../../../shared/components/ui/form/hooks/use_form_action';
 
 export default function DonationFormWithHeaders( props ) {
 	const Translations = useContext( TranslationContext );
@@ -26,6 +27,7 @@ export default function DonationFormWithHeaders( props ) {
 	] = useAmountWithCustom( null, props.formatters.customAmountInputFormatter );
 	const [ disabledIntervals, setDisabledIntervals ] = useState( [] );
 	const [ disabledPaymentMethods, setDisabledPaymentMethods ] = useState( [] );
+	const [ formAction ] = useFormAction( props );
 
 	const validate = e => {
 		if ( [
@@ -63,8 +65,7 @@ export default function DonationFormWithHeaders( props ) {
 	};
 
 	return <div className="form">
-		<form method="post" name="donationForm" className="form__element"
-			action={ 'https://spenden.wikimedia.de/donation/new?piwik_campaign=' + props.campaignName + '&piwik_kwd=' + props.bannerName}>
+		<form method="post" name="donationForm" className="form__element" action={ formAction }>
 
 			<fieldset className="form__section">
 				<legend className="form__section-head">{ Translations[ 'intervals-header' ]}</legend>
@@ -149,7 +150,6 @@ export default function DonationFormWithHeaders( props ) {
 				amount={ props.formatters.amountForServerFormatter( numericAmount ) }
 				interval={ paymentInterval }
 				paymentType={ paymentMethod }
-				impressionCounts={ props.impressionCounts }
 			/>
 		</form>
 	</div>;

--- a/mobile_english/components/ui/form/DonationFormWithHeaders.jsx
+++ b/mobile_english/components/ui/form/DonationFormWithHeaders.jsx
@@ -14,6 +14,7 @@ import usePaymentMethod from '../../../../shared/components/ui/form/hooks/use_pa
 import { amountMessage, validateRequired } from '../../../../shared/components/ui/form/utils';
 import { Intervals, PaymentMethods } from '../../../../shared/components/ui/form/FormItemsBuilder';
 import SubmitValues from '../../../../shared/components/ui/form/SubmitValues';
+import useFormAction from '../../../../shared/components/ui/form/hooks/use_form_action';
 
 export default function DonationFormWithHeaders( props ) {
 	const Translations = useContext( TranslationContext );
@@ -25,6 +26,7 @@ export default function DonationFormWithHeaders( props ) {
 	] = useAmountWithCustom( null, props.formatters.customAmountInputFormatter );
 	const [ disabledIntervals, setDisabledIntervals ] = useState( [] );
 	const [ disabledPaymentMethods, setDisabledPaymentMethods ] = useState( [] );
+	const [ formAction ] = useFormAction( props, { provadd: 1 } );
 
 	const validate = e => {
 		if ( [
@@ -62,8 +64,7 @@ export default function DonationFormWithHeaders( props ) {
 	};
 
 	return <div className="form">
-		<form method="post" name="donationForm" className="form__element"
-			action={ 'https://spenden.wikimedia.de/donation/new?piwik_campaign=' + props.campaignName + '&piwik_kwd=' + props.bannerName}>
+		<form method="post" name="donationForm" className="form__element" action={ formAction }>
 
 			<fieldset className="form__section">
 				<legend className="form__section-head"></legend>
@@ -135,7 +136,6 @@ export default function DonationFormWithHeaders( props ) {
 				amount={ props.formatters.amountForServerFormatter( numericAmount ) }
 				interval={ paymentInterval }
 				paymentType={ paymentMethod }
-				impressionCounts={ props.impressionCounts }
 			/>
 		</form>
 	</div>;

--- a/mobile_english/components/ui/form/DonationFormWithHeaders_var.jsx
+++ b/mobile_english/components/ui/form/DonationFormWithHeaders_var.jsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 import { h } from 'preact';
-import { useContext, useState } from 'preact/hooks';
+import { useContext, useState, useEffect } from 'preact/hooks';
 
 import TranslationContext from '../../../../shared/components/TranslationContext';
 import { SelectGroup } from './SelectGroup_var';
@@ -16,6 +16,7 @@ import { Intervals, PaymentMethods } from '../../../../shared/components/ui/form
 import SubmitValues from '../../../../shared/components/ui/form/SubmitValues';
 import { AddressType } from './FormItemsBuilder';
 import useAddressType from './hooks/use_address_type';
+import useFormAction, { NEW_DONATION_URL, ADD_DONATION_URL } from '../../../../shared/components/ui/form/hooks/use_form_action';
 
 export default function DonationFormWithHeaders( props ) {
 	const Translations = useContext( TranslationContext );
@@ -29,6 +30,12 @@ export default function DonationFormWithHeaders( props ) {
 	const [ disabledIntervals, setDisabledIntervals ] = useState( [] );
 	const [ disabledPaymentMethods, setDisabledPaymentMethods ] = useState( [] );
 	const [ disabledAddressTypes, setDisabledAddressTypes ] = useState( [] );
+	const [ formAction, setUrl ] = useFormAction( props, { provadd: 1 } );
+
+	useEffect(
+		() => setUrl( addressType !== AddressType.NO.value ? NEW_DONATION_URL : ADD_DONATION_URL ),
+		[ addressType ]
+	);
 
 	const addDisabledPaymentMethod = paymentMethodToDisable => {
 		let currentDisabledPaymentMethods = disabledPaymentMethods;
@@ -102,23 +109,6 @@ export default function DonationFormWithHeaders( props ) {
 		}
 	};
 
-	const formActionParams = {
-		piwik_campaign: props.campaignName,
-		piwik_kwd: props.bannerName,
-		provadd: 1
-	};
-
-	const queryString = Object.keys( formActionParams )
-		.map( key => `${key}=${formActionParams[ key ]}` )
-		.join( '&' );
-
-	const getFormAction = () => {
-		if ( addressType !== AddressType.NO.value ) {
-			return 'https://spenden.wikimedia.de/donation/new?' + queryString;
-		}
-		return 'https://spenden.wikimedia.de/donation/add?' + queryString + '&mbt=1';
-	};
-
 	const getButtonText = () => {
 		if ( addressType !== AddressType.NO.value ) {
 			return Translations[ 'submit-label' ];
@@ -139,7 +129,7 @@ export default function DonationFormWithHeaders( props ) {
 
 	return <div className="form">
 		<form method="post" name="donationForm" className="form__element"
-			action={ getFormAction() }>
+			action={ formAction }>
 
 			<fieldset className="form__section">
 				<legend className="form__section-head"></legend>
@@ -227,7 +217,6 @@ export default function DonationFormWithHeaders( props ) {
 				amount={ props.formatters.amountForServerFormatter( numericAmount ) }
 				interval={ paymentInterval }
 				paymentType={ paymentMethod }
-				impressionCounts={ props.impressionCounts }
 				addressType={ addressType }
 			/>
 		</form>

--- a/pad_english/components/ui/form/MultiStepDonationForm.jsx
+++ b/pad_english/components/ui/form/MultiStepDonationForm.jsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 import { h } from 'preact';
-import { useContext, useState } from 'preact/hooks';
+import { useContext, useEffect, useState } from 'preact/hooks';
 import classNames from 'classnames';
 
 import TranslationContext from '../../../../shared/components/TranslationContext';
@@ -15,6 +15,7 @@ import useInterval from '../../../../shared/components/ui/form/hooks/use_interva
 import usePaymentMethod from '../../../../shared/components/ui/form/hooks/use_payment_method';
 import useAddressType from './hooks/use_address_type';
 import { amountMessage, validateRequired } from '../../../../shared/components/ui/form/utils';
+import useFormAction, { ADD_DONATION_URL, NEW_DONATION_URL } from '../../../../shared/components/ui/form/hooks/use_form_action';
 
 const formSteps = Object.freeze( {
 	ONE: Symbol( 'one' ),
@@ -34,6 +35,12 @@ export default function DonationForm( props ) {
 	const [ disabledIntervals, setDisabledIntervals ] = useState( [] );
 	const [ disabledPaymentMethods, setDisabledPaymentMethods ] = useState( [] );
 	const [ disabledAddressTypes, setDisabledAddressTypes ] = useState( [] );
+	const [ formAction, setUrl ] = useFormAction( props, { provadd: 1 } );
+
+	useEffect(
+		() => setUrl( addressType !== AddressType.NO.value ? NEW_DONATION_URL : ADD_DONATION_URL ),
+		[ addressType ]
+	);
 
 	const onSubmitStep1 = e => {
 		e.preventDefault();
@@ -121,23 +128,6 @@ export default function DonationForm( props ) {
 		}
 	};
 
-	const formActionParams = {
-		piwik_campaign: props.campaignName,
-		piwik_kwd: props.bannerName,
-		provadd: 1
-	};
-
-	const queryString = Object.keys( formActionParams )
-		.map( key => `${key}=${formActionParams[ key ]}` )
-		.join( '&' );
-
-	const getFormAction = () => {
-		if ( addressType !== AddressType.NO.value ) {
-			return 'https://spenden.wikimedia.de/donation/new?' + queryString;
-		}
-		return 'https://spenden.wikimedia.de/donation/add?' + queryString + '&mbt=1';
-	};
-
 	const getFormNotice = () => {
 		if ( paymentMethod === PaymentMethods.DIRECT_DEBIT.value ) {
 			return Translations[ 'address-type-notice-direct-debit' ];
@@ -167,7 +157,7 @@ export default function DonationForm( props ) {
 		'form',
 		{ 'is-step-2': formStep === formSteps.TWO }
 	) }>
-		<form method="post" name="donationForm" className="form__element" onClick={ onFormInteraction } action={ getFormAction() }>
+		<form method="post" name="donationForm" className="form__element" onClick={ onFormInteraction } action={ formAction }>
 
 			<div className="form-step-1">
 
@@ -303,7 +293,6 @@ export default function DonationForm( props ) {
 				amount={ props.formatters.amountForServerFormatter( numericAmount ) }
 				interval={ paymentInterval }
 				paymentType={ paymentMethod }
-				impressionCounts={ props.impressionCounts }
 			/>
 
 		</form>

--- a/shared/components/ui/form/DonationForm.jsx
+++ b/shared/components/ui/form/DonationForm.jsx
@@ -13,6 +13,7 @@ import useInterval from './hooks/use_interval';
 import usePaymentMethod from './hooks/use_payment_method';
 import { amountMessage, validateRequired } from './utils';
 import SubmitValues from './SubmitValues';
+import useFormAction from './hooks/use_form_action';
 
 export default function DonationForm( props ) {
 	const Translations = useContext( TranslationContext );
@@ -24,6 +25,7 @@ export default function DonationForm( props ) {
 	] = useAmountWithCustom( null, props.formatters.customAmountInputFormatter );
 	const disabledIntervals = [];
 	const disabledPaymentMethods = [];
+	const [ formAction ] = useFormAction( props );
 
 	const validate = e => {
 		if ( [
@@ -39,8 +41,7 @@ export default function DonationForm( props ) {
 	const onFormInteraction = this.props.onFormInteraction ? e => this.props.onFormInteraction( e ) : () => {};
 
 	return <div className="form">
-		<form method="post" name="donationForm" className="form__element" onClick={ onFormInteraction }
-			action={ 'https://spenden.wikimedia.de/donation/new?piwik_campaign=' + props.campaignName + '&piwik_kwd=' + props.bannerName}>
+		<form method="post" name="donationForm" className="form__element" onClick={ onFormInteraction } action={ formAction }>
 
 			<div className="form-field-group">
 				<SelectGroup

--- a/shared/components/ui/form/SubmitValues.jsx
+++ b/shared/components/ui/form/SubmitValues.jsx
@@ -1,7 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 import { h, Fragment } from 'preact';
 import PropTypes from 'prop-types';
-import { LocalImpressionCount } from '../../../local_impression_count';
 
 export default function SubmitValues( props ) {
 	let addressType = props.addressType || 'person';
@@ -10,8 +9,6 @@ export default function SubmitValues( props ) {
 		<input type="hidden" name="amount" value={ props.amount } />
 		<input type="hidden" name="interval" value={ props.interval } />
 		<input type="hidden" name="paymentType" value={ props.paymentType } />
-		<input type="hidden" name="impCount" value={ props.impressionCounts.overallCount }/>
-		<input type="hidden" name="bImpCount" value={ props.impressionCounts.bannerCount }/>
 	</Fragment>;
 }
 
@@ -19,6 +16,5 @@ SubmitValues.propTypes = {
 	addressType: PropTypes.string,
 	amount: PropTypes.string.isRequired,
 	interval: PropTypes.string.isRequired,
-	paymentType: PropTypes.string.isRequired,
-	impressionCounts: PropTypes.instanceOf( LocalImpressionCount )
+	paymentType: PropTypes.string.isRequired
 };

--- a/shared/components/ui/form/hooks/use_form_action.js
+++ b/shared/components/ui/form/hooks/use_form_action.js
@@ -1,0 +1,27 @@
+import { useState } from 'preact/hooks';
+
+export const NEW_DONATION_URL = 'https://spenden.wikimedia.de/donation/new';
+export const ADD_DONATION_URL = 'https://spenden.wikimedia.de/donation/add';
+
+// When IE is finally dead, we'll use URLSearchParams instead
+const queryString = formActionParams => Object.keys( formActionParams )
+	.map( key => `${key}=${formActionParams[ key ]}` )
+	.join( '&' );
+
+export default function useFormAction( { bannerName, campaignName, impressionCounts }, extraProps = {} ) {
+	const initialQuery = {
+		piwik_kwd: bannerName,
+		piwik_campaign: campaignName,
+		impCount: impressionCounts.overallCount,
+		bImpCount: impressionCounts.bannerCount,
+		...extraProps
+	};
+
+	const [ urlState, setUrlState ] = useState( NEW_DONATION_URL );
+	const [ queryState ] = useState( initialQuery );
+	const setUrl = ( url ) => {
+		const urlWithoutQuery = url.split( '?' )[ 0 ];
+		setUrlState( urlWithoutQuery );
+	};
+	return [ urlState + '?' + queryString( queryState ), setUrl ];
+}

--- a/shared/local_impression_count.js
+++ b/shared/local_impression_count.js
@@ -49,7 +49,7 @@ export class LocalImpressionCount {
 	 * @return {boolean}
 	 */
 	hasLocalStorage() {
-		if ( typeof this.localStorageActive !== undefined ) {
+		if ( this.localStorageActive !== undefined ) {
 			return this.localStorageActive;
 		}
 

--- a/wikipedia.de/mobile/components/ui/form/DonationFormWithHeaders.jsx
+++ b/wikipedia.de/mobile/components/ui/form/DonationFormWithHeaders.jsx
@@ -15,6 +15,7 @@ import { amountMessage, validateRequired } from '../../../../../shared/component
 import { Intervals, PaymentMethods } from './FormItemsBuilder';
 import SubmitValues from '../../../../../shared/components/ui/form/SubmitValues';
 import Footer from '../../../../../shared/components/ui/EasySelectFooter';
+import useFormAction from '../../../../../shared/components/ui/form/hooks/use_form_action';
 
 export default function DonationFormWithHeaders( props ) {
 	const Translations = useContext( TranslationContext );
@@ -26,6 +27,7 @@ export default function DonationFormWithHeaders( props ) {
 	] = useAmountWithCustom( null, props.formatters.customAmountInputFormatter );
 	const [ disabledIntervals, setDisabledIntervals ] = useState( [] );
 	const [ disabledPaymentMethods, setDisabledPaymentMethods ] = useState( [] );
+	const [ formAction ] = useFormAction( props );
 
 	const validate = e => {
 		if ( [
@@ -63,8 +65,7 @@ export default function DonationFormWithHeaders( props ) {
 	};
 
 	return <div className="form">
-		<form method="post" name="donationForm" className="form__element"
-			action={ 'https://spenden.wikimedia.de/donation/new?piwik_campaign=' + props.campaignName + '&piwik_kwd=' + props.bannerName}>
+		<form method="post" name="donationForm" className="form__element" action={ formAction}>
 
 			<fieldset className="form__section">
 				<legend className="form__section-head">{ Translations[ 'intervals-header' ]}</legend>

--- a/wikipedia.de/mobile/components/ui/form/DonationFormWithHeaders_var.jsx
+++ b/wikipedia.de/mobile/components/ui/form/DonationFormWithHeaders_var.jsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 import { h } from 'preact';
-import { useContext, useState } from 'preact/hooks';
+import { useContext, useEffect, useState } from 'preact/hooks';
 
 import TranslationContext from '../../../../../shared/components/TranslationContext';
 import { SelectGroup } from './SelectGroup_var';
@@ -17,6 +17,7 @@ import SubmitValues from '../../../../../shared/components/ui/form/SubmitValues'
 import Footer from '../../../../../shared/components/ui/EasySelectFooter';
 import { AddressType } from './FormItemsBuilder';
 import useAddressType from './hooks/use_address_type';
+import useFormAction, { ADD_DONATION_URL, NEW_DONATION_URL } from '../../../../../shared/components/ui/form/hooks/use_form_action';
 
 export default function DonationFormWithHeaders( props ) {
 	const Translations = useContext( TranslationContext );
@@ -30,6 +31,12 @@ export default function DonationFormWithHeaders( props ) {
 	const [ disabledIntervals, setDisabledIntervals ] = useState( [] );
 	const [ disabledPaymentMethods, setDisabledPaymentMethods ] = useState( [] );
 	const [ disabledAddressTypes, setDisabledAddressTypes ] = useState( [] );
+	const [ formAction, setUrl ] = useFormAction( props, { provadd: 1 } );
+
+	useEffect(
+		() => setUrl( addressType !== AddressType.NO.value ? NEW_DONATION_URL : ADD_DONATION_URL ),
+		[ addressType ]
+	);
 
 	const addDisabledPaymentMethod = paymentMethodToDisable => {
 		let currentDisabledPaymentMethods = disabledPaymentMethods;
@@ -103,23 +110,6 @@ export default function DonationFormWithHeaders( props ) {
 		}
 	};
 
-	const formActionParams = {
-		piwik_campaign: props.campaignName,
-		piwik_kwd: props.bannerName,
-		provadd: 1
-	};
-
-	const queryString = Object.keys( formActionParams )
-		.map( key => `${key}=${formActionParams[ key ]}` )
-		.join( '&' );
-
-	const getFormAction = () => {
-		if ( addressType !== AddressType.NO.value ) {
-			return 'https://spenden.wikimedia.de/donation/new?' + queryString;
-		}
-		return 'https://spenden.wikimedia.de/donation/add?' + queryString + '&mbt=1';
-	};
-
 	const getButtonText = () => {
 		if ( addressType !== AddressType.NO.value ) {
 			return Translations[ 'submit-label-default' ];
@@ -140,7 +130,7 @@ export default function DonationFormWithHeaders( props ) {
 
 	return <div className="form">
 		<form method="post" name="donationForm" className="form__element"
-			action={ getFormAction() }>
+			action={ formAction }>
 
 			<fieldset className="form__section">
 				<legend className="form__section-head">{ Translations[ 'intervals-header' ]}</legend>
@@ -230,7 +220,6 @@ export default function DonationFormWithHeaders( props ) {
 				amount={ props.formatters.amountForServerFormatter( numericAmount ) }
 				interval={ paymentInterval }
 				paymentType={ paymentMethod }
-				impressionCounts={ props.impressionCounts }
 				addressType={ addressType }
 			/>
 		</form>


### PR DESCRIPTION
Add `useFormAction` hook to dynamically generate the form URL and
centralize the query string. This is important because we're moving the
impression count data to the query string (so the fundraising
application frontend code can pick it up without a server round trip).

Currently, the query string is static. If we need it to be reactive, we
can extend useFormAction hook with a `setQuery` function in the future
that has the same signature as useFormAction.

We did not adapt the desktop banner to avoid merge conflicts. This needs
to be done for the next banner.

Co-Authored-By: Abban Dunne <abban.dunne@wikimedia.de>
Co-Authored-By: Corinna Hillebrand <corinna.hillebrand@wikimedia.de>