### PR TITLE
Ignore ESLint 8 update in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,9 @@ updates:
       interval: "weekly"
     reviewers:
       - "wmde/funtech-core"
+    ignore:
+        # Ignore eslint 8 for now, since we're getting ESM/commonjs errors
+        # Remove and re-investigate after Jan 2022
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
       


### PR DESCRIPTION
The update throws too many ESM/commonjs errors where it's unclear if
those errors come from our eslint plugins or eslint itself. We should
investigate and try to update at a later date (e.g. beginning of 2022)