### PR TITLE
Remove slide tracking on banner close

### DIFF
--- a/shared/banner_presenter.js
+++ b/shared/banner_presenter.js
@@ -65,13 +65,11 @@ export default class BannerPresenter {
 				...props,
 				trackingData: this.trackingData,
 				impressionCounts: this.impressionCounts,
-				onClose: ( slidesShown = 0, finalSlide = 0 ) => {
-					this.trackingData.tracker.trackBannerEventWithViewport(
+				onClose: () => {
+					this.trackingData.tracker.trackViewPortDimensions(
 						'banner-closed',
-						slidesShown,
-						finalSlide,
+						sizeIssueIndicator.getDimensions( bannerElement.offsetHeight ),
 						this.trackingData.bannerCloseTrackRatio,
-						sizeIssueIndicator.getDimensions( bannerElement.offsetHeight )
 					);
 					skinAdjuster.removeSpace();
 					window.removeEventListener( 'resize', resizeHandler );


### PR DESCRIPTION
Tracking slide counts is no longer needed here. Banners will still pass slide values to the event but it no longer uses them.

Ticket: https://phabricator.wikimedia.org/T294551
Related to: https://github.com/wmde/fundraising-banners/pull/751