### PR TITLE
Fix B21_WMDE_ipad_en_01_var

### DIFF
--- a/pad_english/components_var/ui/form/DonationForm.jsx
+++ b/pad_english/components_var/ui/form/DonationForm.jsx
@@ -37,8 +37,12 @@ export default function DonationForm( props ) {
 	};
 
 	useEffect(
-		() => setUrl( addressType !== AddressType.NO.value ? NEW_DONATION_URL : ADD_DONATION_URL ),
-		[ addressType, setUrl ]
+		() => {
+			const someAddressData = addressType !== AddressType.NO.value;
+			const paymentNeedsAddress = addressType === PaymentMethods.DIRECT_DEBIT;
+			setUrl( someAddressData || paymentNeedsAddress ? NEW_DONATION_URL : ADD_DONATION_URL );
+		},
+		[ addressType, paymentMethod, setUrl ]
 	);
 
 	const validate = e => {
@@ -75,8 +79,8 @@ export default function DonationForm( props ) {
 		} else {
 			setDisabledIntervals( [] );
 		}
-		if ( e.target.value === PaymentMethods.DIRECT_DEBIT ) {
-			setDisabledAddressTypes( [ AddressType.NO, AddressType.EMAIL ] );
+		if ( e.target.value === PaymentMethods.DIRECT_DEBIT.value ) {
+			setDisabledAddressTypes( [ AddressType.NO.value, AddressType.EMAIL.value ] );
 		} else {
 			setDisabledAddressTypes( [] );
 		}
@@ -84,8 +88,10 @@ export default function DonationForm( props ) {
 
 	const onChangeAddressType = e => {
 		setAddressType( e.target.value );
-		if ( e.target.value !== AddressType.FULL ) {
-			setDisabledPaymentMethods( [ PaymentMethods.DIRECT_DEBIT ] );
+		if ( e.target.value !== AddressType.FULL.value ) {
+			setDisabledPaymentMethods( [ PaymentMethods.DIRECT_DEBIT.value ] );
+		} else {
+			setDisabledPaymentMethods( [] );
 		}
 	};
 

--- a/pad_english/components_var/ui/form/SelectGroup.jsx
+++ b/pad_english/components_var/ui/form/SelectGroup.jsx
@@ -34,7 +34,7 @@ export function SelectGroup( props ) {
 					<label key={ value } className={ classNames(
 						'select-group__option',
 						`select-group__option--${ props.fieldname }-${value.replace( ' ', '-' )}`,
-						{ 'select-group__disabled': props.disabledOptions.indexOf( value ) > -1 }
+						{ 'select-group__option--disabled': props.disabledOptions.indexOf( value ) > -1 }
 					) }>
 						<input
 							type="radio"

--- a/pad_english/styles_var/DonationForm.pcss
+++ b/pad_english/styles_var/DonationForm.pcss
@@ -121,6 +121,18 @@
 					color: $color-black;
 				}
 			}
+
+			&--disabled {
+				cursor: auto;
+				opacity: 0.3;
+
+				&:hover {
+					.select-group__state, {
+						background: $color-white;
+						border-color: $color-gray-medium;
+					}
+				}
+			}
 		}
 
 		&__input {


### PR DESCRIPTION
The check for address and payment types now compares values.
Changes to address type now resets disabled payment types.
Correct BEM naming for disabled elements.
Reflect disabled elements through CSS rules