### PR TITLE
Pre-fill the sms option with text content

### DIFF
--- a/pad_english/components/ui/form/MultiStepDonationForm.jsx
+++ b/pad_english/components/ui/form/MultiStepDonationForm.jsx
@@ -209,7 +209,7 @@ export default function DonationForm( props ) {
 					>
 						<div className="sms-box">
 							<label className="select-group__option">
-								<a href="sms:81190" className="select-group__state">{ Translations[ 'sms-payment-message' ] }</a>
+								<a href="sms:81190;?&body=WIKI" className="select-group__state">{ Translations[ 'sms-payment-message' ] }</a>
 							</label>
 							<span>{ Translations[ 'sms-info-message' ] }</span>
 						</div>

--- a/shared/components/ui/form/SmsBox.jsx
+++ b/shared/components/ui/form/SmsBox.jsx
@@ -6,7 +6,7 @@ export default function SmsBox() {
 	const Translations = useContext( TranslationContext );
 	return <div className="sms-box">
 		<label className="select-group__option">
-			<a href="sms:81190" className="select-group__state">{ Translations[ 'sms-payment-message' ] }</a>
+			<a href="sms:81190;?&body=WIKI" className="select-group__state">{ Translations[ 'sms-payment-message' ] }</a>
 		</label>
 		<span className="sms-box__hint">{ Translations[ 'sms-info-message' ] }</span>
 	</div>;


### PR DESCRIPTION
The user gets guided to their sms app when clicking on the sms-href,
but the SMS is empty, the user might have to return to the banner.

It is possible to prefill the sms with text:
should be tested on android + iOS (versions)
https://stackoverflow.com/questions/6480462/how-to-pre-populate-the-sms-body-text-via-an-html-link

a banner that has the sms text integrated is at
[de.m.wikipedia.org/?banner=WMDE_mobile_sms_testbanner](https://de.m.wikipedia.org/?banner=WMDE_mobile_sms_testbanner)