### PR TITLE
Harmonize amount validation

### DIFF
--- a/shared/components/ui/form/hooks/use_amount.js
+++ b/shared/components/ui/form/hooks/use_amount.js
@@ -9,7 +9,7 @@ function validateAmount( amount ) {
 	if ( amount < 1.0 ) {
 		return AMOUNT_TOO_LOW;
 	}
-	if ( amount > 100000 ) {
+	if ( amount >= 100000 ) {
 		return AMOUNT_TOO_HIGH;
 	}
 	return VALID;


### PR DESCRIPTION
Make amount comparison upper limit operator the same as
https://github.com/wmde/fundraising-payments/blob/master/src/Domain/PaymentDataValidator.php#L86

This avoids off-by-one validation errors
