### PR TITLE
Fix modal fund link for EN ipad

### DIFF
--- a/pad_english/components_var/Banner.jsx
+++ b/pad_english/components_var/Banner.jsx
@@ -242,7 +242,7 @@ export default class Banner extends Component {
 										</a>
 									</div>
 									<div className="banner__infobox">
-										<BannerText dynamicCampaignText={this.dynamicCampaignText} />
+										<BannerText dynamicCampaignText={this.dynamicCampaignText} toggleFundsModal={ this.toggleFundsModal } />
 									</div>
 									<div className="banner__form">
 										<DonationForm


### PR DESCRIPTION
Functionality was missing on 2nd page.

This is for https://phabricator.wikimedia.org/T297943