### PR TITLE
Fix customamount field submit

### DIFF
--- a/english/components/ui/form/DonationForm.jsx
+++ b/english/components/ui/form/DonationForm.jsx
@@ -156,10 +156,18 @@ export default function MultiStepDonationForm( props ) {
 		return Translations[ 'submit-label-default' ];
 	};
 
+	const onFormSubmit = e => {
+		if ( formStep === formSteps.ONE ) {
+			onSubmitStep1( e );
+		} else {
+			onSubmitStep2( e );
+		}
+	};
+
 	return <form method="post" name="donationForm" className={ classNames(
 		'banner__form',
 		{ 'is-step-2': formStep === formSteps.TWO }
-	) } onClick={ onFormInteraction } action={ formAction }>
+	) } onClick={ onFormInteraction } action={ formAction } onSubmit={ onFormSubmit }>
 
 		<div className="form-step-1">
 			<SelectGroup
@@ -187,7 +195,7 @@ export default function MultiStepDonationForm( props ) {
 					fieldname="select-amount"
 					value={ customAmount }
 					selectedAmount={ selectedAmount }
-					onInput={ e => updateCustomAmount( e.target.value ) }
+					onInput={ e => { updateCustomAmount( e.target.value ); validateCustomAmount( e.target.value ); } }
 					onBlur={ e => validateCustomAmount( e.target.value ) }
 					placeholder={ props.customAmountPlaceholder }
 					language={
@@ -211,7 +219,7 @@ export default function MultiStepDonationForm( props ) {
 			</SelectGroup>
 
 			<div className="submit-section button-group">
-				<button className="button-group__button" onClick={ onSubmitStep1 }>
+				<button className="button-group__button" type="submit">
 					<span className="button-group__label">{ Translations[ 'next-button' ] }</span>
 				</button>
 			</div>
@@ -265,7 +273,7 @@ export default function MultiStepDonationForm( props ) {
 			</div>
 
 			<div className="submit-section button-group form-step-2-button">
-				<button className="button-group__button" onClick={ onSubmitStep2 }>
+				<button className="button-group__button" type="submit">
 					<span className="button-group__label">{ getButtonText() }</span>
 				</button>
 			</div>

--- a/english/components/ui/form/DonationForm_var.jsx
+++ b/english/components/ui/form/DonationForm_var.jsx
@@ -159,10 +159,23 @@ export default function MultiStepDonationForm( props ) {
 		return Translations[ 'submit-label-default' ];
 	};
 
-	return <form method="post" name="donationForm" className={ classNames(
-		'banner__form',
-		{ 'is-step-2': formStep === formSteps.TWO }
-	) } onClick={ onFormInteraction } action={ formAction }>
+	const onFormSubmit = e => {
+		if ( formStep === formSteps.ONE ) {
+			onSubmitStep1( e );
+		} else {
+			onSubmitStep2( e );
+		}
+	};
+
+	return <form
+		method="post"
+		name="donationForm"
+		className={ classNames(
+			'banner__form',
+			{ 'is-step-2': formStep === formSteps.TWO }
+		) }
+		onClick={ onFormInteraction } action={ formAction }
+		onSubmit={ onFormSubmit } >
 
 		<div className="form-step-1">
 			<SelectGroup
@@ -190,7 +203,7 @@ export default function MultiStepDonationForm( props ) {
 					fieldname="select-amount"
 					value={ customAmount }
 					selectedAmount={ selectedAmount }
-					onInput={ e => updateCustomAmount( e.target.value ) }
+					onInput={ e => { updateCustomAmount( e.target.value ); validateCustomAmount( e.target.value ); } }
 					onBlur={ e => validateCustomAmount( e.target.value ) }
 					placeholder={ props.customAmountPlaceholder }
 					language={
@@ -214,7 +227,7 @@ export default function MultiStepDonationForm( props ) {
 			</SelectGroup>
 
 			<div className="submit-section button-group">
-				<button className="button-group__button" onClick={ onSubmitStep1 }>
+				<button className="button-group__button" type="submit">
 					<span className="button-group__label">{ Translations[ 'next-button' ] }</span>
 				</button>
 			</div>
@@ -275,7 +288,7 @@ export default function MultiStepDonationForm( props ) {
 			</div>
 
 			<div className="submit-section button-group form-step-2-button">
-				<button className="button-group__button" onClick={ onSubmitStep2 }>
+				<button className="button-group__button" type="submit">
 					<span className="button-group__label">{ getButtonText() }</span>
 				</button>
 			</div>

--- a/mobile/components/ui/form/DonationForm.jsx
+++ b/mobile/components/ui/form/DonationForm.jsx
@@ -78,7 +78,7 @@ export default function DonationFormWithHeaders( props ) {
 	};
 
 	return <div className="form">
-		<form method="post" name="donationForm" className="form__element" action={ formAction }>
+		<form method="post" name="donationForm" className="form__element" action={ formAction } onSubmit={ validate } >
 
 			<fieldset className="form__section">
 				<legend className="form__section-head">{ Translations[ 'intervals-header' ]}</legend>
@@ -113,7 +113,7 @@ export default function DonationFormWithHeaders( props ) {
 							fieldname="select-amount"
 							value={ customAmount }
 							selectedAmount={ selectedAmount }
-							onInput={ e => updateCustomAmount( e.target.value ) }
+							onInput={ e => { updateCustomAmount( e.target.value ); validateCustomAmount( e.target.value ); } }
 							onBlur={ e => validateCustomAmount( e.target.value ) }
 							placeholder={ props.customAmountPlaceholder }
 							language={
@@ -144,7 +144,7 @@ export default function DonationFormWithHeaders( props ) {
 			</fieldset>
 
 			<div className="submit-section button-group">
-				<button className="button-group__button" onClick={ validate }>
+				<button className="button-group__button" type="submit">
 					<span className="button-group__label">{ getButtonText() }</span>
 				</button>
 				{ !isFormValid && (

--- a/mobile_english/components/ui/form/DonationFormWithHeaders.jsx
+++ b/mobile_english/components/ui/form/DonationFormWithHeaders.jsx
@@ -128,7 +128,7 @@ export default function DonationFormWithHeaders( props ) {
 
 	return <div className="form">
 		<form method="post" name="donationForm" className="form__element"
-			action={ formAction }>
+			action={ formAction } onSubmit={ validate }>
 
 			<fieldset className="form__section">
 				<legend className="form__section-head"></legend>
@@ -161,7 +161,7 @@ export default function DonationFormWithHeaders( props ) {
 							fieldname="select-amount"
 							value={ customAmount }
 							selectedAmount={ selectedAmount }
-							onInput={ e => updateCustomAmount( e.target.value ) }
+							onInput={ e => { updateCustomAmount( e.target.value ); validateCustomAmount( e.target.value ); } }
 							onBlur={ e => validateCustomAmount( e.target.value ) }
 							placeholder={ props.customAmountPlaceholder }
 							language={
@@ -207,7 +207,7 @@ export default function DonationFormWithHeaders( props ) {
 			</fieldset>
 
 			<div className="submit-section button-group">
-				<button className="button-group__button" onClick={ validate }>
+				<button className="button-group__button" type="submit">
 					<span className="button-group__label">{ getButtonText() }</span>
 				</button>
 			</div>

--- a/mobile_english/components_var/ui/form/DonationFormWithHeaders.jsx
+++ b/mobile_english/components_var/ui/form/DonationFormWithHeaders.jsx
@@ -128,7 +128,7 @@ export default function DonationFormWithHeaders( props ) {
 
 	return <div className="form">
 		<form method="post" name="donationForm" className="form__element"
-			action={ formAction }>
+			action={ formAction } onSubmit={ validate }>
 
 			<fieldset className="form__section">
 				<legend className="form__section-head"></legend>
@@ -161,7 +161,7 @@ export default function DonationFormWithHeaders( props ) {
 							fieldname="select-amount"
 							value={ customAmount }
 							selectedAmount={ selectedAmount }
-							onInput={ e => updateCustomAmount( e.target.value ) }
+							onInput={ e => { updateCustomAmount( e.target.value ); validateCustomAmount( e.target.value ); } }
 							onBlur={ e => validateCustomAmount( e.target.value ) }
 							placeholder={ props.customAmountPlaceholder }
 							language={
@@ -207,7 +207,7 @@ export default function DonationFormWithHeaders( props ) {
 			</fieldset>
 
 			<div className="submit-section button-group">
-				<button className="button-group__button" onClick={ validate }>
+				<button className="button-group__button" type="submit">
 					<span className="button-group__label">{ getButtonText() }</span>
 				</button>
 			</div>

--- a/pad_english/components/ui/form/MultiStepDonationForm.jsx
+++ b/pad_english/components/ui/form/MultiStepDonationForm.jsx
@@ -153,11 +153,19 @@ export default function DonationForm( props ) {
 
 	};
 
+	const onFormSubmit = e => {
+		if ( formStep === formSteps.ONE ) {
+			onSubmitStep1( e );
+		} else {
+			onSubmitStep2( e );
+		}
+	};
+
 	return <div className={ classNames(
 		'form',
 		{ 'is-step-2': formStep === formSteps.TWO }
 	) }>
-		<form method="post" name="donationForm" className="form__element" onClick={ onFormInteraction } action={ formAction }>
+		<form method="post" name="donationForm" className="form__element" onClick={ onFormInteraction } action={ formAction } onSubmit={ onFormSubmit } >
 
 			<div className="form-step-1">
 
@@ -186,7 +194,7 @@ export default function DonationForm( props ) {
 						<SelectCustomAmount
 							value={ customAmount }
 							selectedAmount={ selectedAmount }
-							onInput={ e => updateCustomAmount( e.target.value ) }
+							onInput={ e => { updateCustomAmount( e.target.value ); validateCustomAmount( e.target.value ); } }
 							onBlur={ e => validateCustomAmount( e.target.value ) }
 							placeholder={ Translations[ 'custom-amount-placeholder' ] }
 							language={
@@ -217,7 +225,7 @@ export default function DonationForm( props ) {
 				</div>
 
 				<div className="submit-section button-group">
-					<button className="button-group__button" onClick={ onSubmitStep1 }>
+					<button className="button-group__button" type="submit">
 						<span className="button-group__label">{ Translations[ 'submit-label-short' ] }</span>
 					</button>
 				</div>
@@ -279,7 +287,7 @@ export default function DonationForm( props ) {
 					</div>
 
 					<div className="submit-section button-group form-step-2-button">
-						<button className="button-group__button" onClick={ onSubmitStep2 }>
+						<button className="button-group__button" type="submit">
 							<span className="button-group__label">{ getButtonText() }</span>
 						</button>
 					</div>

--- a/pad_english/components_var/ui/form/DonationForm.jsx
+++ b/pad_english/components_var/ui/form/DonationForm.jsx
@@ -96,7 +96,7 @@ export default function DonationForm( props ) {
 	};
 
 	return <div className="form">
-		<form method="post" name="donationForm" className="form__element" action={ formAction }>
+		<form method="post" name="donationForm" className="form__element" action={ formAction } onSubmit={ validate }>
 
 			<fieldset className="form__section">
 				<legend className="form__section-head">{ Translations[ 'intervals-header' ]}</legend>
@@ -131,7 +131,7 @@ export default function DonationForm( props ) {
 							fieldname="select-amount"
 							value={ customAmount }
 							selectedAmount={ selectedAmount }
-							onInput={ e => updateCustomAmount( e.target.value ) }
+							onInput={ e => { updateCustomAmount( e.target.value ); validateCustomAmount( e.target.value ); } }
 							onBlur={ e => validateCustomAmount( e.target.value ) }
 							placeholder={ props.customAmountPlaceholder }
 							language={
@@ -179,7 +179,7 @@ export default function DonationForm( props ) {
 			</fieldset>
 
 			<div className="submit-section button-group">
-				<button className={ classNames( 'button-group__button', { 'is-valid': isFormValid() } ) } onClick={ validate }>
+				<button className={ classNames( 'button-group__button', { 'is-valid': isFormValid() } ) } type="submit">
 					<span className="button-group__label">{ Translations[ 'submit-label' ] } <ChevronRightIcon/></span>
 				</button>
 			</div>

--- a/pad_english/styles/SelectGroup.pcss
+++ b/pad_english/styles/SelectGroup.pcss
@@ -107,6 +107,8 @@
 				line-height: 2em;
 				font-size: 0.74em;
 				text-align: center;
+				outline: 0;
+				background: transparent;
 				border: 0;
 			}
 

--- a/shared/components/ui/form/DonationForm.jsx
+++ b/shared/components/ui/form/DonationForm.jsx
@@ -40,7 +40,14 @@ export default function DonationForm( props ) {
 	const onFormInteraction = this.props.onFormInteraction ? e => this.props.onFormInteraction( e ) : () => {};
 
 	return <div className="form">
-		<form method="post" name="donationForm" className="form__element" onClick={ onFormInteraction } action={ formAction }>
+		<form
+			method="post"
+			name="donationForm"
+			className="form__element"
+			onClick={ onFormInteraction }
+			action={ formAction }
+			onSubmit={ validate }
+		>
 
 			<div className="form-field-group">
 				<SelectGroup
@@ -70,13 +77,14 @@ export default function DonationForm( props ) {
 						fieldname="select-amount"
 						value={ customAmount }
 						selectedAmount={ selectedAmount }
-						onInput={ e => updateCustomAmount( e.target.value ) }
-						onBlur={ e => validateCustomAmount( e.target.value ) }
+						onInput={ e => { updateCustomAmount( e.target.value ); validateCustomAmount( e.target.value ); } }
+						onBlur={ e => { validateCustomAmount( e.target.value ); } }
 						placeholder={ props.customAmountPlaceholder }
 						language={
 							/* eslint-disable-next-line dot-notation */
 							Translations[ 'LANGUAGE' ]
 						}
+						o
 					/>
 				</SelectGroup>
 			</div>
@@ -97,7 +105,7 @@ export default function DonationForm( props ) {
 			</div>
 
 			<div className="submit-section button-group">
-				<button className="button-group__button" onClick={ validate }>
+				<button className="button-group__button" type="submit">
 					<span className="button-group__label">{ Translations[ 'submit-label' ] }</span>
 				</button>
 			</div>

--- a/wikipedia.de/desktop/components/MultiStepDonationForm.jsx
+++ b/wikipedia.de/desktop/components/MultiStepDonationForm.jsx
@@ -74,6 +74,14 @@ export default function MultiStepDonationForm( props ) {
 		e.preventDefault();
 	};
 
+	const onFormSubmit = e => {
+		if ( formStep === formSteps.ONE ) {
+			onSubmitStep1( e );
+		} else {
+			onSubmitStep2( e );
+		}
+	};
+
 	const onFormBack = e => {
 		e.preventDefault();
 		setFormStep( formSteps.ONE );
@@ -141,7 +149,7 @@ export default function MultiStepDonationForm( props ) {
 		<form method="post" name="donationForm" className={ classNames(
 			'form__element',
 			{ 'is-step-2': formStep === formSteps.TWO }
-		) } onClick={ onFormInteraction } action={ formAction }>
+		) } onClick={ onFormInteraction } onSubmit={ onFormSubmit } action={ formAction }>
 
 			<div className="form-step-1">
 				<SelectGroup
@@ -169,7 +177,7 @@ export default function MultiStepDonationForm( props ) {
 						fieldname="select-amount"
 						value={ customAmount }
 						selectedAmount={ selectedAmount }
-						onInput={ e => updateCustomAmount( e.target.value ) }
+						onInput={ e => { updateCustomAmount( e.target.value ); validateCustomAmount( e.target.value ); } }
 						onBlur={ e => validateCustomAmount( e.target.value ) }
 						placeholder={ props.customAmountPlaceholder }
 						language={
@@ -193,7 +201,7 @@ export default function MultiStepDonationForm( props ) {
 				</SelectGroup>
 
 				<div className="submit-section button-group">
-					<button className="button-group__button" onClick={ onSubmitStep1 }>
+					<button className="button-group__button" type="submit">
 						<span className="button-group__label">{ step1ButtonText }</span>
 					</button>
 				</div>
@@ -247,7 +255,7 @@ export default function MultiStepDonationForm( props ) {
 				<a href="#" className="form-step-2-custom" onClick={ onFormBackToYearly }>{ Translations[ 'form-step-2-link' ] }</a>
 
 				<div className="submit-section button-group form-step-2-button">
-					<button className="button-group__button" onClick={ onSubmitStep2 }>
+					<button className="button-group__button" type="submit">
 						<span className="button-group__label">{ Translations[ 'form-step-2-button' ] }</span>
 					</button>
 				</div>

--- a/wikipedia.de/mobile/components/ui/form/DonationFormWithHeaders.jsx
+++ b/wikipedia.de/mobile/components/ui/form/DonationFormWithHeaders.jsx
@@ -64,7 +64,7 @@ export default function DonationFormWithHeaders( props ) {
 	};
 
 	return <div className="form">
-		<form method="post" name="donationForm" className="form__element" action={ formAction }>
+		<form method="post" name="donationForm" className="form__element" action={ formAction } onSubmit={ validate }>
 
 			<fieldset className="form__section">
 				<legend className="form__section-head">{ Translations[ 'intervals-header' ]}</legend>
@@ -97,7 +97,7 @@ export default function DonationFormWithHeaders( props ) {
 							fieldname="select-amount"
 							value={ customAmount }
 							selectedAmount={ selectedAmount }
-							onInput={ e => updateCustomAmount( e.target.value ) }
+							onInput={ e => { updateCustomAmount( e.target.value ); validateCustomAmount( e.target.value ); } }
 							onBlur={ e => validateCustomAmount( e.target.value ) }
 							placeholder={ props.customAmountPlaceholder }
 							language={
@@ -127,7 +127,7 @@ export default function DonationFormWithHeaders( props ) {
 			</fieldset>
 
 			<div className="submit-section button-group">
-				<button className="button-group__button" onClick={ validate }>
+				<button className="button-group__button" type="submit">
 					<span className="button-group__label">{ Translations[ 'submit-label' ] }</span>
 				</button>
 			</div>

--- a/wikipedia.de/mobile/components/ui/form/DonationFormWithHeaders_var.jsx
+++ b/wikipedia.de/mobile/components/ui/form/DonationFormWithHeaders_var.jsx
@@ -64,7 +64,7 @@ export default function DonationFormWithHeaders( props ) {
 	};
 
 	return <div className="form">
-		<form method="post" name="donationForm" className="form__element" action={ formAction }>
+		<form method="post" name="donationForm" className="form__element" action={ formAction } onSubmit={ validate }>
 
 			<fieldset className="form__section">
 				<legend className="form__section-head">{ Translations[ 'intervals-header' ]}</legend>
@@ -99,7 +99,7 @@ export default function DonationFormWithHeaders( props ) {
 							fieldname="select-amount"
 							value={ customAmount }
 							selectedAmount={ selectedAmount }
-							onInput={ e => updateCustomAmount( e.target.value ) }
+							onInput={ e => { updateCustomAmount( e.target.value ); validateCustomAmount( e.target.value ); } }
 							onBlur={ e => validateCustomAmount( e.target.value ) }
 							placeholder={ props.customAmountPlaceholder }
 							language={
@@ -130,7 +130,7 @@ export default function DonationFormWithHeaders( props ) {
 			</fieldset>
 
 			<div className="submit-section button-group">
-				<button className="button-group__button" onClick={ validate }>
+				<button className="button-group__button" type="submit">
 					<span className="button-group__label">{ Translations[ 'submit-label' ] }</span>
 				</button>
 			</div>


### PR DESCRIPTION

- the validation should work not only on the submit button of the form
but also if you press [enter] while focussing the customAmount field.

- previously the validation got skipped when pressing [enter]
on the custom Amount input field (with an invalid value inside)

- the fix is now applied to all channels,
also the channels that use a 2step form

- also fixes wrong background on pad-EN ctrl banner in the customAmount field