### PR TITLE
Disable certain interval and payment combinations

### DIFF
--- a/components/DonationForm/DonationForm.jsx
+++ b/components/DonationForm/DonationForm.jsx
@@ -5,14 +5,15 @@ import TranslationContext from '../../shared/components/TranslationContext';
 import { SelectGroup } from './SelectGroup';
 import SelectCustomAmount from './SelectCustomAmount';
 import SmsBox from './SmsBox';
+import SubmitValues from './SubmitValues';
 
-import { isValid, isValidOrUnset } from './hooks/validation_states';
 import useAmountWithCustom from './hooks/use_amount';
 import useInterval from './hooks/use_interval';
 import usePaymentMethod from './hooks/use_payment_method';
-import { amountMessage, validateRequired } from './utils';
-import SubmitValues from './SubmitValues';
 import useFormAction from './hooks/use_form_action';
+import { isValid, isValidOrUnset } from './hooks/validation_states';
+import { useDisabledFormValues } from './hooks/use_disabled_form_values';
+import { amountMessage, validateRequired } from './utils';
 
 export default function DonationForm( props ) {
 	const Translations = useContext( TranslationContext );
@@ -22,8 +23,7 @@ export default function DonationForm( props ) {
 		{ numericAmount, amountValidity, selectedAmount, customAmount },
 		{ selectAmount, updateCustomAmount, validateCustomAmount, setAmountValidity }
 	] = useAmountWithCustom( null, props.formatters.customAmountInputFormatter );
-	const disabledIntervals = [];
-	const disabledPaymentMethods = [];
+	const [ disabledIntervals, disabledPaymentMethods ] = useDisabledFormValues( paymentInterval, paymentMethod );
 	const [ formAction ] = useFormAction( props );
 	const [ isFormValid, setFormValidity ] = useState( true );
 

--- a/components/DonationForm/DonationFormPreselectableAmount.jsx
+++ b/components/DonationForm/DonationFormPreselectableAmount.jsx
@@ -5,14 +5,15 @@ import TranslationContext from '../../shared/components/TranslationContext';
 import { SelectGroup } from './SelectGroup';
 import SelectCustomAmount from './SelectCustomAmount';
 import SmsBox from './SmsBox';
+import SubmitValues from './SubmitValues';
 
-import { isValid, isValidOrUnset } from './hooks/validation_states';
 import useAmountWithCustom from './hooks/use_amount';
 import useInterval from './hooks/use_interval';
 import usePaymentMethod from './hooks/use_payment_method';
-import { amountMessage, validateRequired } from './utils';
-import SubmitValues from './SubmitValues';
 import useFormAction from './hooks/use_form_action';
+import { isValid, isValidOrUnset } from './hooks/validation_states';
+import { useDisabledFormValues } from './hooks/use_disabled_form_values';
+import { amountMessage, validateRequired } from './utils';
 
 export default function DonationFormPreselectableAmount( props ) {
 	const Translations = useContext( TranslationContext );
@@ -22,8 +23,7 @@ export default function DonationFormPreselectableAmount( props ) {
 		{ numericAmount, amountValidity, selectedAmount, customAmount },
 		{ selectAmount, updateCustomAmount, validateCustomAmount, setAmountValidity }
 	] = useAmountWithCustom( props.preselectedAmount, props.formatters.customAmountInputFormatter );
-	const disabledIntervals = [];
-	const disabledPaymentMethods = [];
+	const [ disabledIntervals, disabledPaymentMethods ] = useDisabledFormValues( paymentInterval, paymentMethod );
 	const [ formAction ] = useFormAction( props );
 	const [ isFormValid, setFormValidity ] = useState( true );
 
@@ -35,7 +35,7 @@ export default function DonationFormPreselectableAmount( props ) {
 		if ( props.preselectedAmount ) {
 			selectAmount( props.preselectedAmount );
 		}
-	}, [ props.preselectedAmount ] );
+	}, [ props.preselectedAmount, selectAmount ] );
 
 	const validate = e => {
 		if ( [

--- a/components/DonationForm/hooks/use_disabled_form_values.js
+++ b/components/DonationForm/hooks/use_disabled_form_values.js
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'preact/hooks';
+import { Intervals, PaymentMethods } from '../FormItemsBuilder';
+
+const AllIntervalsExceptOnce = Object.values( Intervals ).reduce(
+	( intervals, interval ) => {
+		if ( interval.value !== Intervals.ONCE.value ) {
+			intervals.push( interval.value );
+		}
+		return intervals;
+	},
+	[]
+);
+
+/**
+ * This hook implements the "business logic" for checking invalid combinations of
+ * payment intervals and methods, returning lists of disabled intervals or methods
+ * when one of them is selected. These lists can then be passed into the SelectGroup
+ * components.
+ *
+ * As long as the SelectGroup makes it impossible to select an invalid value,
+ * there is no need to set the complimentary, already selected value to null.
+ *
+ * @param {string} currentInterval
+ * @param {string} currentPaymentMethod
+ * @return {Array}
+ */
+export const useDisabledFormValues = function ( currentInterval, currentPaymentMethod ) {
+	const [ disabledIntervals, setDisabledIntervals ] = useState( [] );
+	const [ disabledPaymentMethods, setDisabledPaymentMethods ] = useState( [] );
+
+	useEffect(
+		() => {
+			if ( currentInterval === Intervals.ONCE.value || currentInterval === null ) {
+				setDisabledPaymentMethods( [] );
+			} else {
+				setDisabledPaymentMethods( [ PaymentMethods.SOFORT.value ] );
+			}
+		},
+		[ currentInterval ]
+	);
+
+	useEffect(
+		() => {
+			if ( currentPaymentMethod === PaymentMethods.SOFORT.value ) {
+				setDisabledIntervals( AllIntervalsExceptOnce );
+			} else {
+				setDisabledIntervals( [] );
+			}
+		},
+		[ currentPaymentMethod ]
+	);
+
+	return [ disabledIntervals, disabledPaymentMethods ];
+};


### PR DESCRIPTION
Check for certain combinations of payment interval and method and create a list of disabled values for the complementary value.

Reorder imports to put components and hooks together.

Fix linter warning in DonationFormPreselectableAmount.