### PR TITLE
Add Vector 2022 skin

### DIFF
--- a/campaign_info.toml
+++ b/campaign_info.toml
@@ -24,6 +24,18 @@ tracking = "org-06-220916-var"
 platform = ["edge", "ie11", "firefox_win10", "chrome_win10", "safari", "firefox_macos", "chrome_macos", "firefox_linux", "chrome_linux"]
 resolution = ["800x600", "1024x768", "1280x960", "1600x1200", "1920x1200", "2560x1440"]
 
+[desktop_vector_2022]
+campaign_tracking = "06-ba-220916"
+preview_link = "/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&useskin=vector-2022&banner=B17WMDE_webpack_prototype"
+preview_url = 'https://de.wikipedia.org/wiki/Wikipedia:Hauptseite?banner={{PLACEHOLDER}}'
+wrapper_template = "wikipedia_org"
+
+# Banners of the campaign, key after "banners" can be anything
+[desktop_vector_2022.banners.ctrl]
+filename = "./banners/desktop/banner_ctrl.js"
+pagename = "B22_WMDE_Test_06_ctrl_desktop_vector_2022"
+tracking = "org-06-220916-ctrl"
+
 # Mobile Campaign
 [mobile]
 campaign_tracking = "mob04-ba-220905"

--- a/shared/skin/index.js
+++ b/shared/skin/index.js
@@ -1,10 +1,11 @@
 import Minerva from './minerva';
 import Monobook from './monobook';
 import Vector from './vector';
+import Vector2022 from './vector-2022';
 import Wpde from './wpde';
 import { onMediaWiki } from '../mediawiki_checks';
 
-export { Minerva, Monobook, Vector };
+export { Minerva, Monobook, Vector, Vector2022 };
 export { default as Wpde } from './wpde';
 
 export function getSkinAdjuster() {
@@ -20,6 +21,8 @@ export function getSkinAdjuster() {
 			return new Monobook();
 		case 'vector':
 			return new Vector();
+		case 'vector-2022':
+			return new Vector2022();
 		default:
 			return new Vector();
 	}

--- a/shared/skin/minerva.js
+++ b/shared/skin/minerva.js
@@ -8,25 +8,23 @@ export default class Minerva extends Skin {
 		super();
 
 		this.viewport = $( '#mw-mf-viewport' );
+		this.navigation = $( '#mw-mf-page-left' );
 		this.searchField = $( '#searchInput, input.search' );
 	}
 
 	addSpace( bannerHeight, transition ) {
-		this.viewport.css( {
-			top: bannerHeight,
-			transition: transition.createTransitionValue( 'top' )
-		} );
+		this.viewport.css( { top: bannerHeight, transition: transition.createTransitionValue( 'top' ) } );
+		this.navigation.css( { top: bannerHeight, transition: transition.createTransitionValue( 'top' ) } );
 	}
 
 	addSpaceInstantly( bannerHeight ) {
-		this.viewport.css( {
-			top: bannerHeight,
-			transition: 'unset'
-		} );
+		this.viewport.css( { top: bannerHeight, transition: 'unset' } );
+		this.navigation.css( { top: bannerHeight, transition: 'unset' } );
 	}
 
 	removeSpace() {
 		this.viewport.css( { top: 0, marginTop: 0, transition: 'unset' } );
+		this.navigation.css( { top: 0, marginTop: 0, transition: 'unset' } );
 	}
 
 	addSearchObserver( onSearchFocusWhenBannerIsLoading, onSearchFocusWhenBannerIsVisible ) {

--- a/shared/skin/vector-2022.js
+++ b/shared/skin/vector-2022.js
@@ -1,0 +1,50 @@
+import Skin from './Skin';
+import $ from 'jquery';
+
+// usually desktop skin
+
+export default class Vector2022 extends Skin {
+	constructor() {
+		super();
+
+		this.container = $( '.mw-page-container' );
+		this.searchField = $( '#searchInput' );
+		this.hidePopup();
+	}
+
+	addSpace( bannerHeight, transition ) {
+		this.container.css( { paddingTop: bannerHeight, transition: transition.createTransitionValue( 'padding-top' ) } );
+	}
+
+	addSpaceInstantly( bannerHeight ) {
+		this.container.css( { paddingTop: bannerHeight, transition: 'unset' } );
+	}
+
+	removeSpace() {
+		this.container.css( { paddingTop: 0, transition: 'unset' } );
+	}
+
+	addSearchObserver( onSearchFocusWhenBannerIsLoading ) {
+		this.searchField.one( 'focus', onSearchFocusWhenBannerIsLoading );
+	}
+
+	addEditorObserver( onEdit ) {
+		$( '#ca-ve-edit, .mw-editsection-visualeditor' ).click( onEdit );
+	}
+
+	moveBannerContainerToTopOfDom() {
+		$( 'body' ).prepend( $( '#centralNotice' ) );
+	}
+
+	getSizeIssueThreshold() {
+		return 160;
+	}
+
+	hidePopup() {
+		$( 'head' ).prepend( '<style>.mw-notification-area-overlay { display: none; }</style>' );
+	}
+
+	getName() {
+		return 'vector';
+	}
+}


### PR DESCRIPTION
* The sidebar in the Minerva skin wasn't being pushed down by the banner and when a user clicked the navigation icon it was popping out behind it.
* Support making banner space on the new Vector skin.

Ticket: https://phabricator.wikimedia.org/T318136

Please note that the campaign settings to show the desktop banner on the new skin should be removed before merging