### PR TITLE
Fix infinite loop in DonationFormPreselectableAmount

### DIFF
--- a/components/DonationForm/DonationFormPreselectableAmount.jsx
+++ b/components/DonationForm/DonationFormPreselectableAmount.jsx
@@ -35,7 +35,8 @@ export default function DonationFormPreselectableAmount( props ) {
 		if ( props.preselectedAmount ) {
 			selectAmount( props.preselectedAmount );
 		}
-	}, [ props.preselectedAmount, selectAmount ] );
+		/* eslint-disable-next-line */
+	}, [ props.preselectedAmount ] );
 
 	const validate = e => {
 		if ( [

--- a/shared/create_dynamic_campaign_text.js
+++ b/shared/create_dynamic_campaign_text.js
@@ -17,13 +17,13 @@ export default function createDynamicCampaignText( campaignParameters, campaignP
 		campaignParameters.millionImpressionsPerDay,
 		formatters.integerFormatter( campaignProjection.getProjectedNumberOfDonors() ),
 		campaignDays.getDaysSinceCampaignStart(),
-		translations[ 'visitors-vs-donors-sentence' ]
+		translations[ 'visitors-vs-donors-sentence' ] ?? ''
 	);
 	const donorsNeeded = campaignProjection.getRemainingDonorsNeeded();
 	const donorsNeededRoundedUp = donorsNeeded > 100 ? Math.round( campaignProjection.getRemainingDonorsNeeded() / 100 ) * 100 : donorsNeeded;
 	const donorsNeededSentence = new DonorsNeededSentence(
 		formatters.integerFormatter( donorsNeededRoundedUp ),
-		translations[ 'remaining-donors-needed-sentence' ]
+		translations[ 'remaining-donors-needed-sentence' ] ?? ''
 	);
 
 	return {


### PR DESCRIPTION
When the hook watches a method, calling that method seems to trigger the hook making it loop infinitely. This removes the watcher and tells the linter to ignore the missing dependency.