### PR TITLE
C22_WMDE_Mobile_Test_05_2

### DIFF
--- a/campaign_info.toml
+++ b/campaign_info.toml
@@ -38,20 +38,20 @@ tracking = "org-06-220916-ctrl"
 
 # Mobile Campaign
 [mobile]
-campaign_tracking = "mob05-ba-220927"
+campaign_tracking = "mob05-ba-221012"
 preview_link = "/mobile/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&useskin=minerva&banner=B17WMDE_webpack_prototype"
 preview_url = 'https://de.m.wikipedia.org/wiki/Wikipedia:Hauptseite?banner={{PLACEHOLDER}}'
 wrapper_template = "wikipedia_org"
 
 [mobile.banners.ctrl]
 filename = "./banners/mobile/banner_ctrl.js"
-pagename = "B22_WMDE_Mobile_Test_05_ctrl"
-tracking = "org-mob05-220927-ctrl"
+pagename = "B22_WMDE_Mobile_Test_05_2_ctrl"
+tracking = "org-mob05-221012-ctrl"
 
 [mobile.banners.var]
 filename = "./banners/mobile/banner_var.js"
-pagename = "B22_WMDE_Mobile_Test_05_var"
-tracking = "org-mob05-220927-var"
+pagename = "B22_WMDE_Mobile_Test_05_2_var"
+tracking = "org-mob05-221012-var"
 
 [mobile.test_matrix]
 device = [ 'samsung_s10', 'iphone_xs_max', 'iphone_5s', 'iphone_se', "iphone_8", "iphone_12_mini", "iphone_7_plus", "iphone_11_pro_max"]


### PR DESCRIPTION
Update configuration for C22_WMDE_Mobile_Test_05_2. This is so we can tag the specific banner release that was run after it was fixed.

Ticket: https://phabricator.wikimedia.org/T320601