### PR TITLE
Update Visitors vs Donors sentence

### DIFF
--- a/shared/create_dynamic_campaign_text.js
+++ b/shared/create_dynamic_campaign_text.js
@@ -16,8 +16,8 @@ export default function createDynamicCampaignText( campaignParameters, campaignP
 	const visitorsVsDonorsSentence = new VisitorsVsDonorsSentence(
 		campaignParameters.millionImpressionsPerDay,
 		formatters.integerFormatter( campaignProjection.getProjectedNumberOfDonors() ),
-		campaignDays.getDaysSinceCampaignStart(),
-		translations[ 'visitors-vs-donors-sentence' ] ?? ''
+		translations[ 'visitors-vs-donors-sentence' ] ?? '',
+		translations[ 'visitors-vs-donors-sentence-no-impressions' ] ?? ''
 	);
 	const donorsNeeded = campaignProjection.getRemainingDonorsNeeded();
 	const donorsNeededRoundedUp = donorsNeeded > 100 ? Math.round( campaignProjection.getRemainingDonorsNeeded() / 100 ) * 100 : donorsNeeded;

--- a/shared/messages/de.js
+++ b/shared/messages/de.js
@@ -39,6 +39,8 @@ const Translations = {
 	'campaign-day-nth-day': 'Heute ist der {{days}}. Tag unserer Spendenkampagne.',
 	'campaign-day-only-n-days': 'In {{days}} Tagen endet unsere Spendenkampagne.',
 	'campaign-day-last-day': 'Es bleibt nur noch ein Tag, um Wikipedia in diesem Jahr zu unterstützen.',
+	'visitors-vs-donors-sentence-no-impressions': 'Millionenfach wird unser Spendenaufruf täglich angezeigt,' +
+		' aber nur {{totalNumberOfDonors}} Menschen haben bisher gespendet.',
 	'visitors-vs-donors-sentence': 'Über {{millionImpressionsPerDay}} Millionen Mal wird unser Spendenaufruf täglich angezeigt,' +
 		' aber nur {{totalNumberOfDonors}} Menschen haben bisher gespendet.',
 

--- a/shared/messages/en.js
+++ b/shared/messages/en.js
@@ -39,8 +39,10 @@ const Translations = {
 	'campaign-day-nth-day': 'This is the {{days}} day of our campaign.',
 	'campaign-day-only-n-days': 'Only {{days}} days left to donate for Wikipedia this year.',
 	'campaign-day-last-day': 'Today is the final day of our donation campaign.',
-	'visitors-vs-donors-sentence': 'Our fundraising appeal is displayed over {{millionImpressionsPerDay}} million ' +
-		'times a day, but currently only {{totalNumberOfDonors}} people have donated.',
+	'visitors-vs-donors-sentence-no-impressions': 'Our fundraising appeal is displayed several million times a day,' +
+		' but currently only {{totalNumberOfDonors}} people have donated.',
+	'visitors-vs-donors-sentence': 'Our fundraising appeal is displayed over {{millionImpressionsPerDay}} million' +
+		' times a day, but currently only {{totalNumberOfDonors}} people have donated.',
 
 	'interval-once': 'one-time',
 	'interval-monthly': 'monthly',

--- a/shared/visitors_vs_donors_sentence.js
+++ b/shared/visitors_vs_donors_sentence.js
@@ -5,24 +5,21 @@ export default class VisitorsVsDonorsSentence {
 	/**
 	 * @param {number} millionImpressionsPerDay
 	 * @param {string} projectedNumberOfDonors
-	 * @param {number} daysSinceCampaignStart
 	 * @param {string} text
+	 * @param {string} textNoImpressions
 	 */
-	constructor( millionImpressionsPerDay, projectedNumberOfDonors, daysSinceCampaignStart, text ) {
+	constructor( millionImpressionsPerDay, projectedNumberOfDonors, text, textNoImpressions ) {
 		this.millionImpressionsPerDay = millionImpressionsPerDay;
 		this.projectedNumberOfDonors = projectedNumberOfDonors;
-		this.daysSinceCampaignStart = daysSinceCampaignStart;
 		this.text = text;
+		this.textNoImpressions = textNoImpressions;
 	}
 
 	getSentence() {
-		if ( this.daysSinceCampaignStart >= 1 ) {
-			return this.text
-				.replace( '{{millionImpressionsPerDay}}', this.millionImpressionsPerDay.toString() )
-				.replace( '{{totalNumberOfDonors}}', this.projectedNumberOfDonors );
-		}
-		return '';
-
+		const text = this.millionImpressionsPerDay === 0 ? this.textNoImpressions : this.text;
+		return text
+			.replace( '{{millionImpressionsPerDay}}', this.millionImpressionsPerDay.toString() )
+			.replace( '{{totalNumberOfDonors}}', this.projectedNumberOfDonors );
 	}
 
 }


### PR DESCRIPTION
Change the requirements for showing the
sentence so one of 2 items are always shown

Ticket: https://phabricator.wikimedia.org/T320474

This has been added to https://github.com/wmde/fundraising-banners/pull/1054 so you can use that branch for acceptance testing