### PR TITLE
Validate custom amount on submit only

### DIFF
--- a/components/DonationForm/BegYearlyRecurringDonationForm.jsx
+++ b/components/DonationForm/BegYearlyRecurringDonationForm.jsx
@@ -49,6 +49,9 @@ export default function BegYearlyRecurringDonationForm( props ) {
 	);
 
 	const onSubmitStep1 = e => {
+		if ( customAmount ) {
+			validateCustomAmount( customAmount );
+		}
 		if ( [
 			[ intervalValidity, setIntervalValidity ],
 			[ amountValidity, setAmountValidity ],
@@ -201,7 +204,7 @@ export default function BegYearlyRecurringDonationForm( props ) {
 							fieldname="select-amount"
 							value={ customAmount }
 							selectedAmount={ selectedAmount }
-							onInput={ e => { updateCustomAmount( e.target.value ); validateCustomAmount( e.target.value ); } }
+							onInput={ e => updateCustomAmount( e.target.value ) }
 							onBlur={ e => validateCustomAmount( e.target.value ) }
 							placeholder={ props.customAmountPlaceholder }
 							language={

--- a/components/DonationForm/DonationForm.jsx
+++ b/components/DonationForm/DonationForm.jsx
@@ -32,6 +32,9 @@ export default function DonationForm( props ) {
 	}, [ intervalValidity, amountValidity, paymentMethodValidity ] );
 
 	const validate = e => {
+		if ( customAmount ) {
+			validateCustomAmount( customAmount );
+		}
 		if ( [
 			[ intervalValidity, setIntervalValidity ],
 			[ amountValidity, setAmountValidity ],
@@ -83,19 +86,13 @@ export default function DonationForm( props ) {
 					fieldname="select-amount"
 					value={ customAmount }
 					selectedAmount={ selectedAmount }
-					onInput={ e => {
-						updateCustomAmount( e.target.value );
-						validateCustomAmount( e.target.value );
-					} }
-					onBlur={ e => {
-						validateCustomAmount( e.target.value );
-					} }
+					onInput={ e => updateCustomAmount( e.target.value ) }
+					onBlur={ e => validateCustomAmount( e.target.value ) }
 					placeholder={ props.customAmountPlaceholder }
 					language={
 						/* eslint-disable-next-line dot-notation */
 						Translations[ 'LANGUAGE' ]
 					}
-					o
 				/>
 			</SelectGroup>
 		</fieldset>


### PR DESCRIPTION
Validation was added to the custom amount
onValueChanged event in order to stop people
getting past validation by pressing enter
on their keyboards. This prevented people
being able to donate decimals, however.

This fix moves the custom amount validation
to the onSubmit method instead

You can see this working in https://www.wikipedia.de/?banner=B22WPDE_mob01_ctrl