### PR TITLE
Make the shared goal donation sum numeric

### DIFF
--- a/shared/create_dynamic_campaign_text.js
+++ b/shared/create_dynamic_campaign_text.js
@@ -34,6 +34,6 @@ export default function createDynamicCampaignText( campaignParameters, campaignP
 		// FIXME: impressionCounts is not a reactive property this variable doesn't get
 		//        incremented when the banner presenter updates it, we need to figure that out
 		overallImpressionCount: impressionCounts.getOverallCount() + 1,
-		goalDonationSum: formatters.millionFormatter( campaignProjection.goalDonationSum / 1000000 )
+		goalDonationSum: formatters.millionFormatterNumeric( campaignProjection.goalDonationSum )
 	};
 }


### PR DESCRIPTION
This is used in the Slides and BannerText components and the extra text doesn't always match with the
required copy. So we now create only the number and let it be manually formatted.