### PR TITLE
Update only the content dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ ci: test lint ## Run continuous integration tasks (linting, testing)
 clean: ## Clean up dist directory
 	docker-compose run js-build npm run clean
 
+update-content:
+	docker-compose run js-build npm update fundraising-frontend-content
+
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "webpack serve --host 0.0.0.0",
     "clean": "rimraf dist/*.js dist/*.wikitext dist/*.map",
     "lint:js": "eslint --ext .jsx --ext .js --cache --cache-location .eslintcache --ignore-path .gitignore .",
-    "lint:css": "stylelint '**/*.pcss'"
+    "lint:css": "stylelint '**/*.pcss'",
+    "update-content": "npm update fundraising-frontend-content"
   },
   "keywords": [],
   "author": "gabriel.birke@wikimedia.de",


### PR DESCRIPTION
we often need to keep the content up to date for the banners, but other dependencies should not always be updated to not break some functionality during the campaign for example