### PR TITLE
Add links to central notice settings to banner overview

### DIFF
--- a/webpack/banner_selection_list.hbs
+++ b/webpack/banner_selection_list.hbs
@@ -5,7 +5,16 @@
 		<h2>{{ @key }}</h2>
 		<ul>
 			{{#each banners }}
-				<li><a href="{{ bannerlink ../this pagename }}" target="_blank">{{ pagename }}</a></li>
+				<li>
+					<a href="{{ bannerlink ../this pagename }}"
+							target="_blank"
+							title="preview banner locally">
+						{{ pagename }}
+					</a>
+					( <a href="{{ centralNoticeLink ../this pagename }}"
+						target="_blank"
+						title="Edit banner settings on CentralNotice or github (WPDE)">▶️️</a> )
+				</li>
 			{{/each}}
 		</ul>
 	{{/each}}

--- a/webpack/loader.js
+++ b/webpack/loader.js
@@ -16,6 +16,13 @@ Handlebars.registerHelper( 'bannerlink', function ( campaign, bannername ) {
 	return campaign.preview_link.replace( '{{banner}}', bannername );
 } );
 
+Handlebars.registerHelper( 'centralNoticeLink', function ( campaign, bannername ) {
+	if ( bannername.includes( 'WPDE' ) ) {
+		return 'https://github.com/wmde/wikipedia.de-banners/blob/master/campaigns.yml';
+	}
+	return 'https://meta.wikimedia.org/wiki/Special:CentralNoticeBanners/edit/{{banner}}'.replace( '{{banner}}', bannername );
+} );
+
 if ( !currentUrl.query.devbanner ) {
 
 	$( 'body' ).html( bannerSelectionListTemplate( { campaigns: CAMPAIGNS } ) );


### PR DESCRIPTION
Shows the link to the respective edit page on Central Notice (or for WPDE: campaign settings file on github) for each banner on the development entry page