### PR TITLE
Remove JS linter warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,8 @@ module.exports = exports = {
 		mocha: true
 	},
 	'globals': {
-		mw: false
+		mw: false,
+		JSX: true
 	},
 	'plugins': [
 		'react'

--- a/banners/pad/components/Banner_var.jsx
+++ b/banners/pad/components/Banner_var.jsx
@@ -267,6 +267,7 @@ export default class Banner extends Component {
 						<div className="wmde-banner-content">
 							<div className="wmde-banner-column-left">
 								<div className="wmde-banner-content-headline">
+									{ /* eslint-disable-next-line react/no-danger */ }
 									<span className="wmde-banner-content-headline-text" dangerouslySetInnerHTML={
 										{ __html: props.translations[ 'content-headline' ] }
 									}></span>

--- a/components/DonationForm/BegYearlyRecurringDonationFormCompact.jsx
+++ b/components/DonationForm/BegYearlyRecurringDonationFormCompact.jsx
@@ -26,7 +26,7 @@ const formSteps = Object.freeze( {
  * The only difference between this and the BegYearlyRecurringDonationForm
  * is that the SMS notice needed to be moved under the select options.
  *
- * @param props
+ * @param {Object} props
  * @return {JSX.Element}
  * @constructor
  */

--- a/components/DonationForm/BegYearlyRecurringDonationFormStep2MobileCompact.jsx
+++ b/components/DonationForm/BegYearlyRecurringDonationFormStep2MobileCompact.jsx
@@ -9,13 +9,17 @@ export default function BegYearlyRecurringDonationFormStep2( props ) {
 
 	// 1. The button clicks update the value of alternative.
 	// 2. We watch the value of alternative for changes
-	// 3. If the value is not null we know the user clicked a button so we submit the form
-	useEffect( () => {
-		if ( props.upgradeToYearly !== null ) {
-			props.onSubmit();
-			props.formRef.current.submit();
-		}
-	}, [ props.upgradeToYearly ] );
+	// 3. If the value is not null we know the user clicked a button, so we submit the form
+	useEffect(
+		() => {
+			if ( props.upgradeToYearly !== null ) {
+				props.onSubmit();
+				props.formRef.current.submit();
+			}
+		},
+		/* eslint-disable-next-line react-hooks/exhaustive-deps  */
+		[ props.upgradeToYearly ]
+	);
 
 	const onClickAlternativeButton = e => {
 		e.preventDefault();

--- a/components/DonationForm/BegYearlyRecurringDonationFormStep2MobileModal.jsx
+++ b/components/DonationForm/BegYearlyRecurringDonationFormStep2MobileModal.jsx
@@ -9,13 +9,17 @@ export default function BegYearlyRecurringDonationFormStep2( props ) {
 
 	// 1. The button clicks update the value of alternative.
 	// 2. We watch the value of alternative for changes
-	// 3. If the value is not null we know the user clicked a button so we submit the form
-	useEffect( () => {
-		if ( props.upgradeToYearly !== null ) {
-			props.onSubmit();
-			props.formRef.current.submit();
-		}
-	}, [ props.upgradeToYearly ] );
+	// 3. If the value is not null we know the user clicked a button, so we submit the form
+	useEffect(
+		() => {
+			if ( props.upgradeToYearly !== null ) {
+				props.onSubmit();
+				props.formRef.current.submit();
+			}
+		},
+		/* eslint-disable-next-line react-hooks/exhaustive-deps  */
+		[ props.upgradeToYearly ]
+	);
 
 	const onClickAlternativeButton = e => {
 		e.preventDefault();

--- a/components/SoftClose/SoftClose.jsx
+++ b/components/SoftClose/SoftClose.jsx
@@ -80,6 +80,7 @@ export default class SoftClose extends Component {
 					</div>
 				</div>
 
+				{/* eslint-disable-next-line react/no-danger */}
 				<div className="wmde-banner-soft-close-column wmde-banner-soft-close-countdown-text" dangerouslySetInnerHTML={ {
 					__html: Translations[ 'soft-close-countdown-text' ].replace( '{{seconds}}', state.secondsRemaining )
 				} }></div>

--- a/components/SoftClose/SoftCloseWithSubscriptionsButton.jsx
+++ b/components/SoftClose/SoftCloseWithSubscriptionsButton.jsx
@@ -102,6 +102,7 @@ export default class SoftCloseWithSubscriptionsButton extends Component {
 					</div>
 				</div>
 
+				{/* eslint-disable-next-line react/no-danger */}
 				<div className="wmde-banner-soft-close-column wmde-banner-soft-close-countdown-text" dangerouslySetInnerHTML={ {
 					__html: Translations[ 'soft-close-countdown-text' ].replace( '{{seconds}}', state.secondsRemaining )
 				} }></div>

--- a/components/UseOfFunds/FundsContent.jsx
+++ b/components/UseOfFunds/FundsContent.jsx
@@ -23,6 +23,7 @@ export default function FundsContent( props ) {
 		</div>
 
 		<div className="use_of_funds__section">
+			{/* eslint-disable-next-line react/no-danger */}
 			<p className="use_of_funds__info_text" dangerouslySetInnerHTML={ { __html: content.detailedReports.mixed.text } }></p>
 		</div>
 		<div className="use_of_funds__section use_of_funds__section--two-cols">

--- a/components/UseOfFunds/FundsDistributionAccordion.jsx
+++ b/components/UseOfFunds/FundsDistributionAccordion.jsx
@@ -37,6 +37,7 @@ export default class FundsDistributionAccordion extends Component {
 				>
 					{fundsItem.title} {fundsItem.percentage}%
 				</div>
+				{/* eslint-disable-next-line react/no-danger */}
 				<div className="funds_distribution_info_item__text" dangerouslySetInnerHTML={ { __html: fundsItem.text } }></div>
 			</div> )}
 

--- a/components/UseOfFunds/FundsDistributionInfo.jsx
+++ b/components/UseOfFunds/FundsDistributionInfo.jsx
@@ -44,6 +44,7 @@ export default class FundsDistributionInfo extends Component {
 			{applicationOfFundsData.map( fundsItem => <div
 				key={fundsItem.id}
 				className={classNames( 'funds_distribution_info__text', { active: isActive( fundsItem.id ) } ) }
+				/* eslint-disable-next-line react/no-danger */
 				dangerouslySetInnerHTML={ { __html: fundsItem.text } }>
 			</div> )}
 


### PR DESCRIPTION
Add ignores where we have false positives from ESLint:

- `react-hooks/exhaustive-deps`: we don't want to pass some values to `useEffect`, that has led to infinite loops in the past
- `react/no-danger`: allow dangerouslySetInnerHTML for I18N content