### PR TITLE
Link to the current branch on github

### DIFF
--- a/dashboard/components/Dashboard.jsx
+++ b/dashboard/components/Dashboard.jsx
@@ -30,7 +30,12 @@ export default function Dashboard( props ) {
 	return <div>
 		<header className="header">
 			<div className="header-left">
-				<h1>FUN Forge</h1> <a className="header-link header-git" target="_blank" href="https://github.com/wmde/fundraising-banners"><IconGit/> { branchInfo }</a>
+				<h1>FUN Forge</h1>
+				<a className="header-link header-git"
+					target="_blank"
+					href={`https://github.com/wmde/fundraising-banners/tree/${branchInfo}`}>
+					<IconGit/> { branchInfo }
+				</a>
 			</div>
 			<div className="header-right">
 				<a href="https://meta.wikimedia.org/w/index.php?title=Special:CentralNotice" className="header-link">CN</a>


### PR DESCRIPTION
... instead of linking to the general banner repo.

When trying out the current implementation I noticed that the link in the headline is linking to the general repo, but the text says <branch name>, so it might be more useful to link to the branch code