### PR TITLE
Fix mobile browsers tests

### DIFF
--- a/banners/mobile/components/Banner.jsx
+++ b/banners/mobile/components/Banner.jsx
@@ -291,7 +291,7 @@ export default class Banner extends Component {
 				</FollowupTransition>
 				<div
 					ref={ this.softCloseTransitionRef }
-					className="soft-close-container banner-position--state-finished banner-position banner-position--fixed"
+					className="soft-close-container"
 					style="top: 0px"
 				>
 					<SoftClose

--- a/banners/mobile/styles/Banner.pcss
+++ b/banners/mobile/styles/Banner.pcss
@@ -13,6 +13,13 @@
 		font-weight: bold;
 	}
 
+	.soft-close-container {
+		position: fixed;
+		left: 0;
+		width: 100%;
+		z-index: 10000;
+	}
+
 	&--visible,
 	&--soft-closing {
 		visibility: visible;


### PR DESCRIPTION
The wrapper-element for the soft-close element had classes that are reserved for the BannerTransition element and that confused the test code.