### PR TITLE
Inject tracking data in dev environment

### DIFF
--- a/campaign_info.toml
+++ b/campaign_info.toml
@@ -6,7 +6,7 @@
 [desktop]
 name = "C22_WMDE_Test_22"
 campaign_tracking = "22-ba-221217"
-preview_link = "/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&banner=B17WMDE_webpack_prototype&devMode"
+preview_link = "/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&banner=B22_WMDE_local_prototype&devMode"
 preview_url = 'https://de.wikipedia.org/wiki/Wikipedia:Hauptseite?banner={{PLACEHOLDER}}'
 wrapper_template = "wikipedia_org"
 
@@ -30,7 +30,7 @@ resolution = ["800x600", "1024x768", "1280x960", "1600x1200", "1920x1200", "2560
 [mobile]
 name = "C22_WMDE_Mobile_Test_13"
 campaign_tracking = "mob13-ba-221213"
-preview_link = "/mobile/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&useskin=minerva&banner=B17WMDE_webpack_prototype&devMode"
+preview_link = "/mobile/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&useskin=minerva&banner=B22_WMDE_local_prototype&devMode"
 preview_url = 'https://de.m.wikipedia.org/wiki/Wikipedia:Hauptseite?banner={{PLACEHOLDER}}'
 wrapper_template = "wikipedia_org"
 
@@ -53,7 +53,7 @@ orientation = [ "portrait", "landscape"]
 [mobile_english]
 name = "C22_WMDE_Mobile_EN_Test_02"
 campaign_tracking = "mob_en02-ba-221206"
-preview_link = "/en-mobile/wiki/Main_Page?devbanner={{banner}}&useskin=minerva&banner=B17WMDE_webpack_prototype&devMode"
+preview_link = "/en-mobile/wiki/Main_Page?devbanner={{banner}}&useskin=minerva&banner=B22_WMDE_local_prototype&devMode"
 preview_url = 'https://en.m.wikipedia.org/wiki/Main_Page?banner={{PLACEHOLDER}}'
 wrapper_template = "wikipedia_org"
 
@@ -76,7 +76,7 @@ orientation = [ "portrait", "landscape" ]
 [pad]
 name = "C22_WMDE_ipad_Test_02"
 campaign_tracking = "pad02-ba-221207"
-preview_link = "/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&banner=B17WMDE_webpack_prototype&devMode"
+preview_link = "/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&banner=B22_WMDE_local_prototype&devMode"
 preview_url = 'https://de.wikipedia.org/wiki/Wikipedia:Hauptseite?banner={{PLACEHOLDER}}'
 wrapper_template = "wikipedia_org"
 
@@ -99,7 +99,7 @@ orientation = [ "portrait", "landscape"]
 [pad_en]
 name = "C22_WMDE_ipad_en_Test_02"
 campaign_tracking = "en-ipad02-221212"
-preview_link = "/wiki/Main_Page?devbanner={{banner}}&banner=B17WMDE_webpack_prototype&devMode"
+preview_link = "/wiki/Wikipedia:Hauptseite?devbanner={{banner}}&banner=B22_WMDE_local_prototype&devMode"
 preview_url = 'https://en.wikipedia.org/wiki/Main_Page?banner={{PLACEHOLDER}}'
 wrapper_template = "wikipedia_org"
 
@@ -162,7 +162,7 @@ tracking = "wpde-mob01-221103-var"
 [english]
 name = "C22_WMDE_Test_EN_06"
 campaign_tracking = "en06-ba-221201"
-preview_link = "/wiki/Main_Page?devbanner={{banner}}&banner=B17WMDE_webpack_prototype&devMode"
+preview_link = "/wiki/Main_Page?devbanner={{banner}}&banner=B22_WMDE_local_prototype&devMode"
 preview_url = 'https://en.wikipedia.org/wiki/Main_Page?banner={{PLACEHOLDER}}'
 wrapper_template = "wikipedia_org"
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,8 @@ module.exports = () => Promise.all( [
 	{
 		mode: 'development',
 		entry: {
-			main: './dashboard/main.js'
+			main: './dashboard/main.js',
+			inject_tracking: './webpack/inject_tracking.js'
 		},
 		plugins: [
 			new webpack.HotModuleReplacementPlugin(),

--- a/webpack/inject_tracking.js
+++ b/webpack/inject_tracking.js
@@ -1,0 +1,17 @@
+// Entry point for injecting tracking data for currently shown banner in the development environment.
+// In a compiled banner, the tracking data is baked into the data attribute of the container div.
+
+import CampaignConfig from './campaign_config';
+
+// eslint-disable-next-line no-undef
+const campaigns = new CampaignConfig( CAMPAIGNS );
+const pages = campaigns.getConfigForPages();
+const currentUrl = new URL( window.location.href );
+const currentBanner = currentUrl.searchParams.get( 'devbanner' );
+const container = document.getElementById( 'WMDE-Banner-Container' );
+if ( pages[ currentBanner ] ) {
+	container.dataset.tracking = pages[ currentBanner ].tracking;
+	container.dataset[ 'campaign-tracking' ] = pages[ currentBanner ].campaign_tracking;
+} else {
+	console.log( `Banner "${currentBanner}" not found in campaign configuration, can't inject tracking` );
+}


### PR DESCRIPTION
Re-introduce injection of tracking parameters as data attributes into container element of local dev environment.

This is a bugfix followup for #1153