### PR TITLE
Fix inject tracking

### DIFF
--- a/webpack/inject_tracking.js
+++ b/webpack/inject_tracking.js
@@ -11,7 +11,7 @@ const currentBanner = currentUrl.searchParams.get( 'devbanner' );
 const container = document.getElementById( 'WMDE-Banner-Container' );
 if ( pages[ currentBanner ] ) {
 	container.dataset.tracking = pages[ currentBanner ].tracking;
-	container.dataset[ 'campaign-tracking' ] = pages[ currentBanner ].campaign_tracking;
+	container.dataset.campaignTracking = pages[ currentBanner ].campaign_tracking;
 } else {
 	console.log( `Banner "${currentBanner}" not found in campaign configuration, can't inject tracking` );
 }


### PR DESCRIPTION
The 'campaign-tracking' dataset item setter
was throwing an error.

TIL: Dataset items should be set in camelCase and are
converted into kebab-case automatically. See:
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset#name_conversion