### PR TITLE
Change the local server port number to 9084

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build: clean setup ## Build all banners into dist directory
 setup: ## Install all npm dependencies
 	docker-compose run js-build npm install
 
-server: ## Start development server on http://localhost:8084/
+server: ## Start development server on http://localhost:9084/
 	docker-compose up js-serve
 
 lint-js:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can preview the banners by running the built-in server.
 
     make server
 
-The preview server is at [http://localhost:8084/](http://localhost:8084/)
+The preview server is at [http://localhost:9084/](http://localhost:9084/)
 
 It will display a selection of banners to preview in their respective channel (German Wikimedia / mobile German Wikipedia / wikipedia.de).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,5 @@ services:
   js-serve:
     extends: js-build
     ports:
-      - "8084:8084"
+      - "9084:9084"
     command: "npm run start"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,7 @@ module.exports = () => Promise.all( [
 			} )
 		],
 		devServer: {
-			'port': 8084,
+			'port': 9084,
 			'allowedHosts': 'all',
 			'static': [
 				{


### PR DESCRIPTION
- As the latest banner repository uses '8084' port, we need to change this repository's port to '9094'